### PR TITLE
Make generated service classes namespace-aware

### DIFF
--- a/src/Service.php
+++ b/src/Service.php
@@ -109,7 +109,7 @@ class Service
 
     // Create the class object
     $comment = new \phpSource\PhpDocComment($this->description);
-    $this->class = new \phpSource\PhpClass($name, $config->getClassExists(), 'SoapClient', $comment);
+    $this->class = new \phpSource\PhpClass($name, $config->getClassExists(), '\SoapClient', $comment);
 
     // Create the constructor
     $comment = new \phpSource\PhpDocComment();
@@ -143,7 +143,7 @@ class Service
     {
       if($type instanceof \wsdl2php\ComplexType)
       {
-        $init .= "  '".$type->getIdentifier()."' => '".$type->getPhpIdentifier()."',".\PHP_EOL;
+        $init .= "  '".$type->getIdentifier()."' => '".(($ns = $config->getNamespaceName()) ? $ns . '\\' : '').$type->getPhpIdentifier()."',".\PHP_EOL;
       }
     }
     $init = \substr($init, 0, \strrpos($init, ','));


### PR DESCRIPTION
Note that the class_exists() checks are still invalid, but as those are generated in a separate library, I didn't want to make the modifications there to fetch the config and grab the namespace.  We could force the classExists configuration to false when a namespace is specified, but I figured I would leave that to discretion.
