### PR TITLE
track returns

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -212,7 +212,7 @@ class Generator
 
       $this->log($this->display('Loading function ').$function);
 
-      $this->service->addOperation($function, $params, $this->documentation->getFunctionDescription($function));
+      $this->service->addOperation($function, $params, $this->documentation->getFunctionDescription($function), $returns);
     }
 
     $this->log($this->display('Done loading service ').$name);

--- a/src/Operation.php
+++ b/src/Operation.php
@@ -33,15 +33,23 @@ class Operation
 
   /**
    *
+   * @var string A description of the operation
+   */
+  private $returns;
+
+  /**
+   *
    * @param string $name
    * @param array $paramStr The parameter string for a operation from the wsdl
    * @param string $description
+   * @param string $returns
    */
-  function __construct($name, $paramStr, $description)
+  function __construct($name, $paramStr, $description, $returns)
   {
     $this->name = $name;
     $this->params = array();
     $this->description = $description;
+    $this->returns = $returns;
 
     $this->generateParams($paramStr);
   }
@@ -62,6 +70,15 @@ class Operation
   public function getDescription()
   {
     return $this->description;
+  }
+
+  /**
+   *
+   * @return string
+   */
+  public function getReturns()
+  {
+    return $this->returns;
   }
 
   /**

--- a/src/Service.php
+++ b/src/Service.php
@@ -158,6 +158,7 @@ class Service
 
       $comment = new PhpDocComment($operation->getDescription());
       $comment->setAccess(PhpDocElementFactory::getPublicAccess());
+	  $comment->setReturn(PhpDocElementFactory::getReturn($operation->getReturns(), ''));
 
       foreach ($operation->getParams() as $param => $hint)
       {
@@ -184,10 +185,11 @@ class Service
    * @param string $name
    * @param array $params
    * @param string $description
+   * @param string $returns
    */
-  public function addOperation($name, $params, $description)
+  public function addOperation($name, $params, $description, $returns)
   {
-    $this->operations[] = new Operation($name, $params, $description);
+    $this->operations[] = new Operation($name, $params, $description, $returns);
   }
 
   /**


### PR DESCRIPTION
currently the generated wsdl operation methods have no @return PHPDoc's. This patch adds it
