### PR TITLE
fix annotation for operations

### DIFF
--- a/src/Service.php
+++ b/src/Service.php
@@ -42,7 +42,7 @@ class Service
 
   /**
    *
-   * @var array An array containing the operations of the service
+   * @var Operation[] An array containing the operations of the service
    */
   private $operations;
 


### PR DESCRIPTION
Change the PHPDoc for $operations to Operation[], instead of array
