### PR TITLE
map some non-php types

### DIFF
--- a/lib/phpSource/PhpDocElementFactory.php
+++ b/lib/phpSource/PhpDocElementFactory.php
@@ -39,6 +39,11 @@ class PhpDocElementFactory
     {
       $name = substr($name, 1);
     }
+	if ($dataType == 'long') {
+		$dataType = 'int';
+	} else if ($dataType == 'double') {
+		$dataType = 'float';
+	}
 
     return new PhpDocElement('param', $dataType, $name, $description);
   }


### PR DESCRIPTION
wsdl may have simple types that don't directly map to php types. Remap some of them to php types
