### PR TITLE
Remove leftover usage of gettext functions.

### DIFF
--- a/lib/Wsdl2PhpGenerator/Cli/Cli.php
+++ b/lib/Wsdl2PhpGenerator/Cli/Cli.php
@@ -130,13 +130,13 @@ class Cli extends CliParser
      */
     public function showUsage()
     {
-        print _('Usage: ') . $this->programName . ' ' . $this->usageString . PHP_EOL;
+        print 'Usage: ' . $this->programName . ' ' . $this->usageString . PHP_EOL;
 
         foreach ($this->acceptedFlags as $flag) {
             print $flag;
         }
 
-        print _('Version: ') . $this->version . PHP_EOL;
+        print 'Version: ' . $this->version . PHP_EOL;
 
         print PHP_EOL;
         exit;
@@ -154,7 +154,7 @@ class Cli extends CliParser
 
         // Add the help flag if not defined
         if (array_key_exists('-h', $this->acceptedFlags) === false) {
-            $this->acceptedFlags['-h'] = new Flag('-h', _('Help'), true);
+            $this->acceptedFlags['-h'] = new Flag('-h', 'Help', true);
         }
 
         if ($this->getValue('-h')) {
@@ -171,7 +171,7 @@ class Cli extends CliParser
                 }
 
                 if ($showError) {
-                    print _('Required parameter missing!') . PHP_EOL;
+                    print 'Required parameter missing!' . PHP_EOL;
                     $this->showUsage();
                 }
             }
@@ -182,7 +182,7 @@ class Cli extends CliParser
 
             if ($flag) {
                 if ($flag->isBool() === false && $value === true) {
-                    print _('A flag that must have a parameter does not') . PHP_EOL;
+                    print 'A flag that must have a parameter does not' . PHP_EOL;
                     $this->showUsage();
                 }
             }

--- a/src/Wsdl2PhpGenerator/Operation.php
+++ b/src/Wsdl2PhpGenerator/Operation.php
@@ -143,12 +143,12 @@ class Operation
             if ($paramType == $type->getIdentifier()) {
                 if ($type instanceof Pattern) {
                     $ret['type'] = $type->getDatatype();
-                    $ret['desc'] = _('Restriction pattern: ') . $type->getValue();
+                    $ret['desc'] = 'Restriction pattern: ' . $type->getValue();
                 } else {
                     $ret['type'] = $type->getPhpIdentifier();
 
                     if ($type instanceof Enum) {
-                        $ret['desc'] = _('Constant: ') . $type->getDatatype() . ' - ' . _('Valid values: ') . $type->getValidValues();
+                        $ret['desc'] = 'Constant: ' . $type->getDatatype() . ' - ' . 'Valid values: ' . $type->getValidValues();
                     }
                 }
             }


### PR DESCRIPTION
These were made obsolete after removing support for translation.

This should fix #50.
