### PR TITLE
Add Phing build script to automate releases

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project name="wsdl2phpgenerator" default="release">
+
+    <target name="release" depends="update-app-version, update-changelog" description="Create a release">
+        <echo>Current code changes for release ${version}</echo>
+        <exec command="git diff HEAD" passthru="true" />
+
+        <!-- Commit changes? No pushing here. Changes should be reviewed again manually beforehand. -->
+        <propertyprompt propertyName="commit" useExistingValue="true" defaultValue="Y"
+                        promptText="Commit and tag changes? [Y/n]" />
+        <if>
+            <equals arg1="${commit}" arg2="Y" />
+            <then>
+                <echo>Committing and tagging release ${version}</echo>
+                <exec command="git add CHANGES generate.php" />
+                <exec command="git commit -m 'Release ${version}'" />
+                <exec command="git tag ${version}" />
+            </then>
+        </if>
+    </target>
+
+    <target name="update-app-version" depends="check-prerequites"
+            description="Updates references to the version in the application code">
+        <reflexive>
+            <fileset dir=".">
+                <filename name="generate.php" />
+            </fileset>
+            <filterchain>
+                <!-- Convert current version number to a token for subsequent replacement with actual value. -->
+                <replaceregexp>
+                    <regexp pattern="(Cli\(.*?)[\d\.]+(\'\);)" replace="\1@VERSION@\2"/>
+                </replaceregexp>
+                <replacetokens begintoken="@" endtoken="@">
+                    <token key="VERSION" value="${version}"/>
+                </replacetokens>
+            </filterchain>
+        </reflexive>
+    </target>
+
+    <target name="update-changelog" depends="check-prerequites"
+            description="Update the changelog with changes for a version.">
+        <exec command="git changelog --tag ${version}" />
+        <!-- Remove merge commits from changelog -->
+        <reflexive>
+            <fileset dir=".">
+                <filename name="CHANGES"/>
+            </fileset>
+            <filterchain>
+                <linecontainsregexp>
+                    <regexp pattern="^((?!\* merge).)*$" ignoreCase="true" />
+                </linecontainsregexp>
+            </filterchain>
+        </reflexive>
+    </target>
+
+    <target name="check-prerequites" description="Check that all required elements are available." hidden="true">
+        <propertyprompt propertyName="version" useExistingValue="true"
+                        promptText="Enter the verson/git tag to work with"  />
+
+        <exec command="git help changelog" outputProperty="git.changelog"/>
+        <condition property="git.changelog.missing" value="true">
+            <contains string="${git.changelog}" substring="no manual entry" casesensitive="false"/>
+        </condition>
+
+        <fail if="git.changelog.missing" message="git changelog must be installed to create a release. See https://github.com/visionmedia/git-extras."/>
+
+        <echo>git changelog: OK</echo>
+    </target>
+
+</project>

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         "ext-soap": "*"
     },
     "require-dev": {
+        "phing/phing": "2.6.*",
         "phpunit/phpunit": "3.7.*",
         "satooshi/php-coveralls": "dev-master"
     }

--- a/composer.lock
+++ b/composer.lock
@@ -3,58 +3,9 @@
         "This file locks the dependencies of your project to a known state",
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file"
     ],
-    "hash": "a9cc6914ce0dac141aa26682ec20d1a7",
+    "hash": "8a6fd24635a78a67ea59c617b30c1db4",
     "packages": [
-        {
-            "name": "symfony/class-loader",
-            "version": "v2.3.6",
-            "target-dir": "Symfony/Component/ClassLoader",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/ClassLoader.git",
-                "reference": "e5f3ef7ebd965a12699984df06b2a5bd439bd2a0"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/ClassLoader/zipball/e5f3ef7ebd965a12699984df06b2a5bd439bd2a0",
-                "reference": "e5f3ef7ebd965a12699984df06b2a5bd439bd2a0",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "require-dev": {
-                "symfony/finder": "~2.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.3-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "Symfony\\Component\\ClassLoader\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "http://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony ClassLoader Component",
-            "homepage": "http://symfony.com",
-            "time": "2013-09-19 09:45:20"
-        }
+
     ],
     "packages-dev": [
         {
@@ -148,6 +99,58 @@
                 "web service"
             ],
             "time": "2013-10-02 20:47:00"
+        },
+        {
+            "name": "phing/phing",
+            "version": "2.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phingofficial/phing.git",
+                "reference": "3f7d71bf561bafea39087250f777b349438cc32e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phingofficial/phing/zipball/3f7d71bf561bafea39087250f777b349438cc32e",
+                "reference": "3f7d71bf561bafea39087250f777b349438cc32e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.2.0"
+            },
+            "bin": [
+                "bin/phing"
+            ],
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "classes/phing/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                "classes"
+            ],
+            "license": [
+                "LGPL3"
+            ],
+            "authors": [
+                {
+                    "name": "Michiel Rook",
+                    "email": "mrook@php.net"
+                },
+                {
+                    "name": "Phing Community",
+                    "homepage": "http://www.phing.info/trac/wiki/Development/Contributors"
+                }
+            ],
+            "description": "PHing Is Not GNU make; it's a PHP project build system or build tool based on Apache Ant.",
+            "homepage": "http://www.phing.info/",
+            "keywords": [
+                "build",
+                "task",
+                "tool"
+            ],
+            "time": "2013-08-26 21:13:03"
         },
         {
             "name": "phpunit/php-code-coverage",


### PR DESCRIPTION
Creating a release involves some tedious manual work that could be streamlined. I have tried to do so using [Phing](http://www.phing.info/docs/guide/stable/).

Using this creating a release (e.g. 2.3.4) should be reduced to:
- `./vendor/bin/phing -Dversion=2.3.4`
- Potentially adjusting `CHANGES`. Commit messages are not always 100% readable
- `git push origin master 2.3,4`

This could be extended with tasks such as:
- Updating gh-pages
- Adding new contributors to README.md
- Building a phar file (as suggsted in #53)

This needs to be updated if #52 is merged.
