### PR TITLE
Move all generated code to separate dir within /tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,5 @@
 build
 wsdl2phpgenerator*.phar
 vendor
-tests/Wsdl2PhpGenerator/Tests/Functional/CurrencyConverterTestCode
-tests/Wsdl2PhpGenerator/Tests/Functional/NaicsTestCode
-tests/Wsdl2PhpGenerator/Tests/Functional/MsSequelServerNativeWebServicesTestCode
-tests/Wsdl2PhpGenerator/Tests/Functional/PayPalSvcTestCode
-tests/Wsdl2PhpGenerator/Tests/Functional/AmazonEc2TestCode
+tests/generated
 TAG_MESSAGE

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,6 +1,7 @@
 filter:
     excluded_paths:
         - 'vendor/*'
+        - 'tests/generated/*'
 before_commands:
     # Use --prefer-source to download dependencies via git and avoid GitHub API
     # rate limits resulting in 502 HTTP responses, build errors and
@@ -11,10 +12,27 @@ tools:
     php_mess_detector:
         config:
             code_size_rules: { cyclomatic_complexity: false, npath_complexity: false }
+        filter:
+            excluded_paths: ['vendor/*']
     php_code_sniffer:
         config:
             standard: PSR2
+        filter:
+            excluded_paths: ['vendor/*']
     php_code_coverage:
         test_command: vendor/bin/phpunit
-    php_cpd: true
-    php_pdepend: true
+        filter:
+            excluded_paths: ['vendor/*']
+    php_cpd:
+        excluded_dirs:
+            - tests/generated
+        filter:
+            excluded_paths: ['vendor/*']
+    php_pdepend:
+        excluded_dirs:
+            1: vendor
+            2: tests/generated
+    php_loc:
+        excluded_dirs:
+            - vendor
+            - tests/generated

--- a/tests/Wsdl2PhpGenerator/Tests/Functional/Wsdl2PhpGeneratorFunctionalTestCase.php
+++ b/tests/Wsdl2PhpGenerator/Tests/Functional/Wsdl2PhpGeneratorFunctionalTestCase.php
@@ -39,7 +39,7 @@ abstract class Wsdl2PhpGeneratorFunctionalTestCase extends PHPUnit_Framework_Tes
     protected function setup()
     {
         $class = new ReflectionClass($this);
-        $this->outputDir = __DIR__ . '/' . $class->getShortName() . 'Code';
+        $this->outputDir = 'tests/generated/' . $class->getShortName();
         $this->generator = Generator::getInstance();
         $this->config = new Config($this->wsdl, $this->outputDir);
 


### PR DESCRIPTION
This makes it easier to ignore for both VCS and Scrutinizer.

Note that this will reduce our Scrunitizer quality score significantly. Our current score of 9,9 is inflated because the generated classes are included in the analysis and they are considered uncomplex, decoupled etc. by default.
