### PR TITLE
Add support to php native DateTime

### DIFF
--- a/src/Wsdl2PhpGenerator/ComplexType.php
+++ b/src/Wsdl2PhpGenerator/ComplexType.php
@@ -78,7 +78,7 @@ class ComplexType extends Type
             $class->addVariable($var);
 
             if (!$member->getNillable()) {
-                if ($type == 'dateTime') {
+                if ($this->config->getAutomaticallyConvertDateTime() && $type == 'dateTime') {
                     $constructorSource .= '  if ($' . $name . ' instanceof \DateTime) {' . PHP_EOL
                         . '    $this->' . $name . ' = $' . $name . '->format(\DateTime::ATOM);' . PHP_EOL
                         . '  } else {' . PHP_EOL
@@ -100,7 +100,7 @@ class ComplexType extends Type
                 $getterComment = new PhpDocComment();
                 $getterComment->setReturn(PhpDocElementFactory::getReturn($type, ''));
                 $getterCode = '';
-                if ($type == 'dateTime') {
+                if ($this->config->getAutomaticallyConvertDateTime() && $type == 'dateTime') {
                     $getterCode = '  if ($this->' . $name . ' == null) {' . PHP_EOL
                         . '    return null;' . PHP_EOL
                         . '  } else {' . PHP_EOL
@@ -116,7 +116,7 @@ class ComplexType extends Type
                 $setterComment = new PhpDocComment();
                 $setterComment->addParam(PhpDocElementFactory::getParam($type, $name, ''));
                 $setterCode = '';
-                if ($type == 'dateTime') {
+                if ($this->config->getAutomaticallyConvertDateTime() && $type == 'dateTime') {
                     $setterCode = '  if ($' . $name . ' instanceof \DateTime) {' . PHP_EOL
                         . '    $this->' . $name . ' = $' . $name . '->format(\DateTime::ATOM);' . PHP_EOL
                         . '  } else {' . PHP_EOL

--- a/src/Wsdl2PhpGenerator/Config.php
+++ b/src/Wsdl2PhpGenerator/Config.php
@@ -126,6 +126,14 @@ class Config implements ConfigInterface
      * @var bool
      */
     private $noIncludes;
+    
+    /**
+     * Automatically convert DateTime to correct string format in constructor
+     * and getters/setters
+     *
+     * @var bool
+     */
+    private $automaticallyConvertDateTime;
 
     /**
      * Sets all variables
@@ -147,8 +155,9 @@ class Config implements ConfigInterface
      * @param bool $createAccessors
      * @param bool $constructorParamsDefaultToNull
      * @param bool $noIncludes
+     * @param bool $automaticallyConvertDateTime
      */
-    public function __construct($inputFile, $outputDir, $verbose = false, $oneFile = false, $classExists = false, $noTypeConstructor = false, $namespaceName = '', $optionsFeatures = array(), $wsdlCache = '', $compression = '', $classNames = '', $prefix = '', $suffix = '', $sharedTypes = false, $createAccessors = false, $constructorParamsDefaultToNull = false, $noIncludes = false)
+    public function __construct($inputFile, $outputDir, $verbose = false, $oneFile = false, $classExists = false, $noTypeConstructor = false, $namespaceName = '', $optionsFeatures = array(), $wsdlCache = '', $compression = '', $classNames = '', $prefix = '', $suffix = '', $sharedTypes = false, $createAccessors = false, $constructorParamsDefaultToNull = false, $noIncludes = false, $automaticallyConvertDateTime = false)
     {
         $this->namespaceName = trim($namespaceName);
         $this->oneFile = $oneFile;
@@ -177,6 +186,7 @@ class Config implements ConfigInterface
         $this->createAccessors = $createAccessors;
         $this->constructorParamsDefaultToNull = $constructorParamsDefaultToNull;
         $this->noIncludes = $noIncludes;
+        $this->automaticallyConvertDateTime = $automaticallyConvertDateTime;
     }
 
     public function getNamespaceName()
@@ -315,6 +325,14 @@ class Config implements ConfigInterface
     }
 
     /**
+     * @return bool $automaticallyConvertDateTime
+     */
+    public function getAutomaticallyConvertDateTime()
+    {
+        return $this->automaticallyConvertDateTime;
+    }
+
+    /**
      * @param boolean $classExists
      */
     public function setClassExists($classExists)
@@ -448,5 +466,13 @@ class Config implements ConfigInterface
     public function setNoIncludes($noIncludes)
     {
         $this->noIncludes = $noIncludes;
+    }
+
+    /**
+     * @param boolean $automaticallyConvertDateTime
+     */
+    public function setAutomaticallyConvertDateTime($automaticallyConvertDateTime)
+    {
+        $this->automaticallyConvertDateTime = $automaticallyConvertDateTime;
     }
 }

--- a/src/Wsdl2PhpGenerator/ConfigInterface.php
+++ b/src/Wsdl2PhpGenerator/ConfigInterface.php
@@ -168,4 +168,17 @@ interface ConfigInterface
      * @return boolean
      */
     public function getConstructorParamsDefaultToNull();
+
+    /**
+     * Returns if DateTime object should be automatically converted to string
+     * in constructor and getters/setters.
+     *
+     * @return boolean
+     */
+    public function getAutomaticallyConvertDateTime();
+
+    /**
+     * @param boolean $automaticallyConvertDateTime
+     */
+    public function setAutomaticallyConvertDateTime($automaticallyConvertDateTime);
 }

--- a/src/Wsdl2PhpGenerator/Console/GenerateCommand.php
+++ b/src/Wsdl2PhpGenerator/Console/GenerateCommand.php
@@ -84,6 +84,14 @@ class GenerateCommand extends Command
                 'createAccessors'
             )
             ->addConfigOption(
+                'convertDateTime',
+                null,
+                InputOption::VALUE_NONE,
+                'Automatically convert DateTime object to string in constructor and getter/setter methods',
+                null,
+                'automaticallyConvertDateTime'
+            )
+            ->addConfigOption(
                 'constructorNull',
                 null,
                 InputOption::VALUE_NONE,


### PR DESCRIPTION
Add support to automatically convert DateTime objects to string in constructor and setters. Convert string to DateTime in getters.
Fix to generate getters/setters also for nullable members
