### PR TITLE
Avoiding collision on class constants

### DIFF
--- a/lib/Wsdl2PhpGenerator/PhpSource/PhpClass.php
+++ b/lib/Wsdl2PhpGenerator/PhpSource/PhpClass.php
@@ -215,34 +215,10 @@ class PhpClass extends PhpElement
         }
 
         if (array_key_exists($name, $this->constants)) {
-            $name = $this->generateNewConstantName($name);
+            throw new Exception('A constant of the name (' . $name . ') does already exist.');
         }
 
         $this->constants[$name] = $value;
-    }
-
-    /**
-     * Try to generate an alternative constant name in case of collision
-     *
-     * @param string $name
-     * @access protected
-     * @return string
-     * @throws Exception
-     */
-    protected function generateNewConstantName($name)
-    {
-        $i = 2;
-        while ($i <= 10) {
-            $newName = $name . '_' . $i++;
-            if (!array_key_exists($newName, $this->constants)) {
-                break;
-            }
-        }
-
-        if ($i > 10) {
-            throw new Exception('A constant of the name (' . $name . ') does already exist.');
-        }
-        return $newName;
     }
 
     /**

--- a/src/Wsdl2PhpGenerator/Enum.php
+++ b/src/Wsdl2PhpGenerator/Enum.php
@@ -66,7 +66,34 @@ class Enum extends Type
                 $first = false;
             }
 
-            $this->class->addConstant($value, $name);
+            $this->addClassConstant($value, $name);
+        }
+    }
+
+    /**
+     * Try to generate an alternative constant name in case of collision
+     *
+     * @param string $name
+     * @access protected
+     * @throws Exception
+     */
+    protected function addClassConstant($value, $name)
+    {
+        $i = 2;
+        $newName = $name;
+        $lastException = null;
+        do {
+            try {
+                $this->class->addConstant($value, $newName);
+                break;
+            } catch (Exception $e) {
+                $newName = $name . '_' . $i++;
+                $lastException = $e;
+            }
+        } while ($i <= 10);
+
+        if ($i > 10) {
+            throw $lastException;
         }
     }
 


### PR DESCRIPTION
This is a change to create alternative constant names instead of fail completely. One example of this case is the wsdl from StrongMail. They have a list of charsets with this:

``` xml
<xs:simpleType name="CharSet">
  <xs:restriction base="xs:string">
    <xs:enumeration value="1046"/>
    <!-- ... -->
    <xs:enumeration value="NF_Z_62-010_1973"/>
    <xs:enumeration value="NF_Z_62-010_(1973)"/>
    <!-- ... -->
  </xs:restriction>
</xs:simpleType>
```

The `Validator` converts the values to `NF_Z_62010_1973` in both cases. With this PR the second constant will be created with the name `NF_Z_62010_1973_2`.
