### PR TITLE
Trimming namespace backslash

### DIFF
--- a/src/Wsdl2PhpGenerator/Service.php
+++ b/src/Wsdl2PhpGenerator/Service.php
@@ -129,7 +129,7 @@ class Service
         $init = 'array(' . PHP_EOL;
         foreach ($this->types as $type) {
             if ($type instanceof ComplexType) {
-                $init .= "  '" . $type->getIdentifier() . "' => '\\" . $this->config->getNamespaceName() . "\\" . $type->getPhpIdentifier() . "'," . PHP_EOL;
+                $init .= "  '" . $type->getIdentifier() . "' => '" . $this->config->getNamespaceName() . "\\" . $type->getPhpIdentifier() . "'," . PHP_EOL;
             }
         }
         $init = substr($init, 0, strrpos($init, ','));


### PR DESCRIPTION
The initial backslash is unnecessary and it was causing the request not translate the classes to the xml request (very weird).

It seems a bug in `SoapClient`, but since the initial backslash is unnecessary, why not just to remove?

For the records, I am using 5.4.23.
