### PR TITLE
Made the SoapClient class configurable.

### DIFF
--- a/src/Wsdl2PhpGenerator/Config.php
+++ b/src/Wsdl2PhpGenerator/Config.php
@@ -128,6 +128,13 @@ class Config implements ConfigInterface
     private $noIncludes;
 
     /**
+     * The class name of the soap client. Defaults to the standard \SoapClient.
+     *
+     * @var string
+     */
+    private $clientClass;
+
+    /**
      * Sets all variables
      *
      * @param string $inputFile
@@ -147,8 +154,9 @@ class Config implements ConfigInterface
      * @param bool $createAccessors
      * @param bool $constructorParamsDefaultToNull
      * @param bool $noIncludes
+     * @param string $clientClass
      */
-    public function __construct($inputFile, $outputDir, $verbose = false, $oneFile = false, $classExists = false, $noTypeConstructor = false, $namespaceName = '', $optionsFeatures = array(), $wsdlCache = '', $compression = '', $classNames = '', $prefix = '', $suffix = '', $sharedTypes = false, $createAccessors = false, $constructorParamsDefaultToNull = false, $noIncludes = false)
+    public function __construct($inputFile, $outputDir, $verbose = false, $oneFile = false, $classExists = false, $noTypeConstructor = false, $namespaceName = '', $optionsFeatures = array(), $wsdlCache = '', $compression = '', $classNames = '', $prefix = '', $suffix = '', $sharedTypes = false, $createAccessors = false, $constructorParamsDefaultToNull = false, $noIncludes = false, $clientClass = '\SoapClient')
     {
         $this->namespaceName = trim($namespaceName);
         $this->oneFile = $oneFile;
@@ -177,6 +185,7 @@ class Config implements ConfigInterface
         $this->createAccessors = $createAccessors;
         $this->constructorParamsDefaultToNull = $constructorParamsDefaultToNull;
         $this->noIncludes = $noIncludes;
+        $this->clientClass = $clientClass;
     }
 
     public function getNamespaceName()
@@ -314,6 +323,11 @@ class Config implements ConfigInterface
         return $this->noIncludes;
     }
 
+    public function getClientClass()
+    {
+        return $this->clientClass;
+    }
+
     /**
      * @param boolean $classExists
      */
@@ -448,5 +462,13 @@ class Config implements ConfigInterface
     public function setNoIncludes($noIncludes)
     {
         $this->noIncludes = $noIncludes;
+    }
+
+    /**
+     * @param string $clientClass
+     */
+    public function setClientClass($clientClass)
+    {
+        $this->clientClass = $clientClass;
     }
 }

--- a/src/Wsdl2PhpGenerator/Generator.php
+++ b/src/Wsdl2PhpGenerator/Generator.php
@@ -7,7 +7,6 @@ namespace Wsdl2PhpGenerator;
 
 use \Exception;
 use Psr\Log\LoggerInterface;
-use \SoapClient;
 use \SoapFault;
 use \DOMDocument;
 use \DOMElement;
@@ -123,9 +122,11 @@ class Generator implements GeneratorInterface
      */
     private function load($wsdl)
     {
+        $clientClass = $this->config->getClientClass();
+
         try {
             $this->log('Loading the wsdl');
-            $this->client = new SoapClient($wsdl, array('cache_wsdl' => WSDL_CACHE_NONE));
+            $this->client = new $clientClass($wsdl, array('cache_wsdl' => WSDL_CACHE_NONE));
         } catch (SoapFault $e) {
             throw new Exception('Error connecting to to the wsdl. Error: ' . $e->getMessage());
         }

--- a/src/Wsdl2PhpGenerator/Service.php
+++ b/src/Wsdl2PhpGenerator/Service.php
@@ -99,7 +99,7 @@ class Service
 
         // Create the class object
         $comment = new PhpDocComment($this->description);
-        $this->class = new PhpClass($name, $this->config->getClassExists(), '\SoapClient', $comment);
+        $this->class = new PhpClass($name, $this->config->getClassExists(), $this->config->getClientClass(), $comment);
 
         // Create the constructor
         $comment = new PhpDocComment();

--- a/tests/Wsdl2PhpGenerator/Tests/Unit/ConfigTest.php
+++ b/tests/Wsdl2PhpGenerator/Tests/Unit/ConfigTest.php
@@ -163,4 +163,16 @@ class ConfigTest extends PHPUnit_Framework_TestCase
     {
         $this->assertEquals('suffix', $this->object->getSuffix());
     }
+
+    public function testGetDefaultClientClass()
+    {
+        $this->assertEquals('\SoapClient', $this->object->getClientClass());
+    }
+
+    public function testGetChangedClientClass()
+    {
+        // create a configuration with a non-default client class
+        $config = new Config('inputFile.xml', '/tmp/output', false, false, false, false, '', array(), '', '', '', '', '', false, false, false, false, 'Namespace\MySoapClient');
+        $this->assertEquals('Namespace\MySoapClient', $config->getClientClass());
+    }
 }


### PR DESCRIPTION
There are use cases where one has to use an extended `SoapClient` class. For example if it is necessary to add support for the [NTLM authentication protocol in order to talk to the SOAP api](http://blogs.msdn.com/b/freddyk/archive/2010/01/19/connecting-to-nav-web-services-from-php.aspx).

This commit makes the default `\SoapClient` class configurable through the `Config` class. Needless to say, it defaults to `\SoapClient` to avoid BC breaks in the first place.

The chosen `$clientClass` is used for connecting to the api in the first place, but also for the generated class files.
