### PR TITLE
Allow indention string to be customized

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ wsdl2phpgenerator*.phar
 vendor
 tests/generated
 TAG_MESSAGE
+.idea

--- a/lib/Wsdl2PhpGenerator/PhpSource/PhpClass.php
+++ b/lib/Wsdl2PhpGenerator/PhpSource/PhpClass.php
@@ -58,14 +58,14 @@ class PhpClass extends PhpElement
 
     /**
      *
-     * @var array Array of PhpVariable objects
+     * @var PhpVariable[] Array of PhpVariable objects
      * @access private
      */
     private $variables;
 
     /**
      *
-     * @var array Array of PhpFunction objects
+     * @var PhpFunction[] Array of PhpFunction objects
      * @access private
      */
     private $functions;
@@ -84,8 +84,9 @@ class PhpClass extends PhpElement
      * @param string $extends A string of the class that this class extends
      * @param PhpDocComment $comment
      * @param bool $final
+     * @param string $indentionStr
      */
-    public function __construct($identifier, $classExists = false, $extends = '', PhpDocComment $comment = null, $final = false)
+    public function __construct($identifier, $classExists = false, $extends = '', PhpDocComment $comment = null, $final = false, $indentionStr = '  ')
     {
         $this->dependencies = array();
         $this->classExists = $classExists;
@@ -97,7 +98,7 @@ class PhpClass extends PhpElement
         $this->constants = array();
         $this->variables = array();
         $this->functions = array();
-        $this->indentionStr = '  '; // Use two spaces as indention
+        $this->indentionStr = $indentionStr;
     }
 
     /**

--- a/src/Wsdl2PhpGenerator/Config.php
+++ b/src/Wsdl2PhpGenerator/Config.php
@@ -128,6 +128,13 @@ class Config implements ConfigInterface
     private $noIncludes;
 
     /**
+     * The string to use for indention.
+     *
+     * @var string
+     */
+    private $indentionStr;
+
+    /**
      * Sets all variables
      *
      * @param string $inputFile
@@ -147,8 +154,9 @@ class Config implements ConfigInterface
      * @param bool $createAccessors
      * @param bool $constructorParamsDefaultToNull
      * @param bool $noIncludes
+     * @param string $indentionStr
      */
-    public function __construct($inputFile, $outputDir, $verbose = false, $oneFile = false, $classExists = false, $noTypeConstructor = false, $namespaceName = '', $optionsFeatures = array(), $wsdlCache = '', $compression = '', $classNames = '', $prefix = '', $suffix = '', $sharedTypes = false, $createAccessors = false, $constructorParamsDefaultToNull = false, $noIncludes = false)
+    public function __construct($inputFile, $outputDir, $verbose = false, $oneFile = false, $classExists = false, $noTypeConstructor = false, $namespaceName = '', $optionsFeatures = array(), $wsdlCache = '', $compression = '', $classNames = '', $prefix = '', $suffix = '', $sharedTypes = false, $createAccessors = false, $constructorParamsDefaultToNull = false, $noIncludes = false, $indentionStr = '  ')
     {
         $this->namespaceName = trim($namespaceName);
         $this->oneFile = $oneFile;
@@ -177,6 +185,7 @@ class Config implements ConfigInterface
         $this->createAccessors = $createAccessors;
         $this->constructorParamsDefaultToNull = $constructorParamsDefaultToNull;
         $this->noIncludes = $noIncludes;
+        $this->indentionStr = $indentionStr;
     }
 
     public function getNamespaceName()

--- a/tests/Wsdl2PhpGenerator/Tests/Unit/CustomIndentionTest.php
+++ b/tests/Wsdl2PhpGenerator/Tests/Unit/CustomIndentionTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Wsdl2PhpGenerator\Tests\Unit;
+
+use Wsdl2PhpGenerator\PhpSource\PhpClass;
+use Wsdl2PhpGenerator\PhpSource\PhpFile;
+use Wsdl2PhpGenerator\PhpSource\PhpVariable;
+
+class CustomIndentionTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Check that when no indention string is specified, the generated code will be indented using the default
+     * indention string, which is a double-space string.
+     */
+    public function testStandardIndention()
+    {
+        $tmpDir = sys_get_temp_dir();
+
+        // create a file with the standard indention
+        $file = new PhpFile('DefaultIndention');
+        $class = new PhpClass('TestClass');
+        $class->addVariable(new PhpVariable('public', 'myVar'));
+        $file->addClass($class);
+        $file->save($tmpDir);
+
+        // assert that the indention level equals the default one
+        preg_match(
+            '/^(?P<indent>[[:space:]]*)public[[:space:]]*\$myVar/m',
+            file_get_contents($tmpDir . DIRECTORY_SEPARATOR . 'DefaultIndention.php'),
+            $matches
+        );
+        $this->assertEquals(2, strlen($matches['indent']));
+    }
+
+    /**
+     * Check that when a custom indention string is specified, the generated code will be indented using that string.
+     */
+    public function testCustomIndention()
+    {
+        $tmpDir = sys_get_temp_dir();
+
+        $indentionStr = '    ';
+
+        // create a file with the standard indention
+        $file = new PhpFile('CustomIndention');
+        $class = new PhpClass('TestClass', false, '', null, false, $indentionStr);
+        $class->addVariable(new PhpVariable('public', 'myVar'));
+        $file->addClass($class);
+        $file->save($tmpDir);
+
+        // assert that the indention level equals the given one
+        preg_match(
+            '/^(?P<indent>[[:space:]]*)public[[:space:]]*\$myVar/m',
+            file_get_contents($tmpDir . DIRECTORY_SEPARATOR . 'CustomIndention.php'),
+            $matches
+        );
+        $this->assertEquals(strlen($indentionStr), strlen($matches['indent']));
+    }
+}


### PR DESCRIPTION
With this patch, the indention string of the generated PHP code can be customized, allowing to increase or decrese the indention level. This can be useful if you want the generated code to be compliant to a specific coding standard. For example, PSR-2 requires that the indention level is 4 spaces, but the standard indention used by Wsdl2PhpGenerator is hardcoded to a 2 spaces string. By setting `$indentionString = '    '` as `Config` class constructor argument, the code will be generated using that custom string instead.
