### PR TITLE
Use 4 spaces as indention, as requested by PSR-2

### DIFF
--- a/lib/Wsdl2PhpGenerator/PhpSource/PhpClass.php
+++ b/lib/Wsdl2PhpGenerator/PhpSource/PhpClass.php
@@ -97,7 +97,7 @@ class PhpClass extends PhpElement
         $this->constants = array();
         $this->variables = array();
         $this->functions = array();
-        $this->indentionStr = '  '; // Use two spaces as indention
+        $this->indentionStr = '    '; // Use 4 spaces as indention, as requested by PSR-2
     }
 
     /**


### PR DESCRIPTION
With this patch, each indention level of the generated code is 4 spaces long. The code is therefore more compliant with PSR-2.
