### PR TITLE
Setters should return themselves to allow method chaining

### DIFF
--- a/src/Wsdl2PhpGenerator/ComplexType.php
+++ b/src/Wsdl2PhpGenerator/ComplexType.php
@@ -119,7 +119,9 @@ class ComplexType extends Type
 
                     $setterComment = new PhpDocComment();
                     $setterComment->addParam(PhpDocElementFactory::getParam($type, $name, ''));
-                    $setter = new PhpFunction('public', 'set' . ucfirst($name), '$' . $name, '  $this->' . $name . ' = $' . $name . ';' . PHP_EOL, $setterComment);
+                    $setterBody = '  $this->' . $name . ' = $' . $name . ';' . PHP_EOL;
+                    $setterBody .= PHP_EOL . '  return $this;' . PHP_EOL;
+                    $setter = new PhpFunction('public', 'set' . ucfirst($name), '$' . $name, $setterBody, $setterComment);
                     $accessors[] = $setter;
                 }
             }


### PR DESCRIPTION
Multiple setter method calls can be chained together by returning `$this` from each setter method.

For example, we can take code that looks like this:

```
$object->setFirstName('John');
$object->setLastName('Smith');
$object->setPhoneNumber('123-456-7890');
```

And simplify it to something like:

```
$object
    ->setFirstName('John')
    ->setLastName('Smith')
    ->setPhoneNumber('123-456-7890');
```
