### PR TITLE
Make members protected if accessor methods are being used

### DIFF
--- a/src/Wsdl2PhpGenerator/ComplexType.php
+++ b/src/Wsdl2PhpGenerator/ComplexType.php
@@ -98,8 +98,13 @@ class ComplexType extends Type
 
             $comment = new PhpDocComment();
             $comment->setVar(PhpDocElementFactory::getVar($type, $name, ''));
-            $comment->setAccess(PhpDocElementFactory::getPublicAccess());
-            $var = new PhpVariable('public', $name, 'null', $comment);
+            if ($this->config->getCreateAccessors()) {
+                $comment->setAccess(PhpDocElementFactory::getProtectedAccess());
+                $var = new PhpVariable('protected', $name, 'null', $comment);
+            } else {
+                $comment->setAccess(PhpDocElementFactory::getPublicAccess());
+                $var = new PhpVariable('public', $name, 'null', $comment);
+            }
             $class->addVariable($var);
 
             if (!$member->getNillable()) {


### PR DESCRIPTION
Accessor methods are generally used instead of (not 'in addition to') direct variable access.  wsdl2phpgenerator currently creates classes where both the variables and the accessor methods are `public`, which makes for a redundant and confusing API.

Well-written classes should only allow getting/setting via one of the two approaches.  If a user of wsdl2phpgenerator wishes to use accessor methods, we should make the variables protected so that only accessor methods can be used.
