### PR TITLE
add a check for minOccurs == 0 when determining member nillable property

### DIFF
--- a/src/Wsdl2PhpGenerator/Generator.php
+++ b/src/Wsdl2PhpGenerator/Generator.php
@@ -137,7 +137,8 @@ class Generator implements GeneratorInterface
                 $this->log('Loading type ' . $type->getPhpIdentifier());
 
                 foreach ($typeNode->getParts() as $name => $typeName) {
-                    $type->addMember($typeName, $name, $typeNode->isElementNillable($name));
+                    $nillable = $typeNode->isElementNillable($name) || $typeNode->getElementMinOccurs($name) === 0;
+                    $type->addMember($typeName, $name, $nillable);
                 }
             } elseif ($enumValues = $typeNode->getEnumerations()) {
                 $type = new Enum($this->config, $typeNode->getName(), $typeNode->getRestriction());

--- a/src/Wsdl2PhpGenerator/Xml/TypeNode.php
+++ b/src/Wsdl2PhpGenerator/Xml/TypeNode.php
@@ -88,6 +88,25 @@ class TypeNode extends XmlNode
     }
 
     /**
+     * Returns the minOccurs value of the element.
+     * @param $name string The name of the sub element
+     * @return int the minOccurs value of the element
+     */
+    public function getElementMinOccurs($name)
+    {
+        foreach ($this->element->getElementsByTagName('element') as $element) {
+            if ($element->getAttribute('name') == $name) {
+                $minOccurs = $element->getAttribute('minOccurs');
+                if ($minOccurs === '') {
+                    return 1;
+                }
+                return $minOccurs;
+            }
+        }
+        return 1;
+    }
+
+    /**
      * Returns the base type for the type.
      *
      * This is used to model inheritance between types.


### PR DESCRIPTION
Currently `Variable.nillable` is set to true only when the wsdl element has the `nillable` attribute set to `true`. 
However this is not the only way (nor the typical way) of making fields accept null values. The "normal" way of making fields accept null values is by setting the `minOccurs` attribute to `0`.
See http://www.ibm.com/developerworks/webservices/library/ws-tip-null/index.html
