### PR TITLE
Fixed default null value for subclass parameters.

### DIFF
--- a/src/Wsdl2PhpGenerator/ComplexType.php
+++ b/src/Wsdl2PhpGenerator/ComplexType.php
@@ -86,6 +86,9 @@ class ComplexType extends Type
                     $constructorComment->addParam(PhpDocElementFactory::getParam($type, $name, ''));
                     $constructorComment->setAccess(PhpDocElementFactory::getPublicAccess());
                     $constructorParameters .= ', $' . $name;
+                    if ($this->config->getConstructorParamsDefaultToNull()) {
+                        $constructorParameters .= ' = null';
+                    }
                 }
             }
             $constructorSource .= '  parent::__construct(' . substr($constructorParameters, 2) . ');' . PHP_EOL;

--- a/tests/Wsdl2PhpGenerator/Tests/Functional/ConstructorParamsDefaultToNullTest.php
+++ b/tests/Wsdl2PhpGenerator/Tests/Functional/ConstructorParamsDefaultToNullTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Wsdl2PhpGenerator\Tests\Functional;
+
+/**
+ * Test handling of the ConstructorParamsDefaultToNull configuration option.
+ */
+class ConstructorParamsDefaultToNullTest extends Wsdl2PhpGeneratorFunctionalTestCase
+{
+
+    protected function getWsdlPath()
+    {
+        return $this->fixtureDir . '/extension/extension.wsdl';
+    }
+
+    protected function configureOptions()
+    {
+        $this->config->setConstructorParamsDefaultToNull(true);
+    }
+
+    public function testConstructorParamsDefaultToNull()
+    {
+        // Load the base class and check that all constructor parameters have a default null value.
+        $this->assertGeneratedClassExists('BaseClass');
+        $object = new \BaseClass();
+        $baseClass = new \ReflectionClass($object);
+        $baseClassConstructor = $baseClass->getConstructor();
+        foreach ($baseClassConstructor->getParameters() as $parameter) {
+            $this->assertEquals(null, $parameter->getDefaultValue(), 'Default constructor parameter value should be null.');
+        }
+
+        // Load the subclass and check that all constructor parameters also exist for the base class and that each of
+        // them defaults to null.
+        $this->assertGeneratedClassExists('DerivedClass1');
+        $subClassObject = new \DerivedClass1();
+        $subClass = new \ReflectionClass($subClassObject);
+        $subClassConstructor = $subClass->getConstructor();
+        foreach ($baseClassConstructor->getParameters() as $baseClassParameter) {
+            $this->assertMethodHasParameter($subClassConstructor, $baseClassParameter);
+        }
+        foreach ($subClassConstructor->getParameters() as $parameter) {
+            $this->assertEquals(null, $parameter->getDefaultValue(), 'Default constructor parameter value for subclasses should be null.');
+        }
+    }
+}

--- a/tests/Wsdl2PhpGenerator/Tests/Functional/Wsdl2PhpGeneratorFunctionalTestCase.php
+++ b/tests/Wsdl2PhpGenerator/Tests/Functional/Wsdl2PhpGeneratorFunctionalTestCase.php
@@ -275,12 +275,17 @@ abstract class Wsdl2PhpGeneratorFunctionalTestCase extends PHPUnit_Framework_Tes
      */
     protected function assertMethodHasParameter(\ReflectionMethod $method, ReflectionParameter $parameter)
     {
-        $parameterNames = array();
+        $parameters = array();
         foreach ($method->getParameters() as $methodParameter) {
-            $parameterNames[] = $methodParameter->getName();
+            $parameters[$methodParameter->getName()] = $methodParameter;
         }
-        $message = (empty($message)) ? sprintf('Parameter "%s" not found among parameter for method "%s->%s" ("%s")', $parameter->getName(), $method->getDeclaringClass()->getName(), $method->getName(), implode('", "', $parameterNames)) : $message;
-        $this->assertContains($parameter->getName(), $parameterNames, $message);
+        $message = (empty($message)) ? sprintf('Parameter "%s" not found among parameter for method "%s->%s" ("%s")', $parameter->getName(), $method->getDeclaringClass()->getName(), $method->getName(), implode('", "', array_keys($parameters))) : $message;
+        $this->assertContains($parameter->getName(), array_keys($parameters), $message);
+
+        // Main attributes for parameters should also be equal.
+        $actualParameter = $parameters[$parameter->getName()] ;
+        $this->assertEquals($actualParameter->getDefaultValue(), $parameter->getDefaultValue(), 'Default values for parameters do not match.');
+        $this->assertEquals($actualParameter->getClass(), $parameter->getClass(), 'Type hinted class for parameters should match');
     }
 
     /**

--- a/tests/fixtures/wsdl/extension/extension.wsdl
+++ b/tests/fixtures/wsdl/extension/extension.wsdl
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions
+  name="extension"
+  targetNamespace="urn:www.example.org:extension"
+  xmlns="http://schemas.xmlsoap.org/wsdl/"
+  xmlns:tns="urn:www.example.org:extension"
+  xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/"
+  xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+  xmlns:wsdlsoap="http://schemas.xmlsoap.org/wsdl/soap/"
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+  <wsdl:types>
+    <schema targetNamespace="urn:www.example.org:extension"
+      xmlns="http://www.w3.org/2001/XMLSchema">
+
+      <complexType name="BaseClass">
+        <sequence>
+          <element name="id" type="xsd:unsignedInt" minOccurs="1"
+            maxOccurs="1"/>
+        </sequence>
+      </complexType>
+
+      <complexType name="DerivedClass1">
+        <complexContent>
+          <extension base="tns:BaseClass">
+            <sequence>
+              <element name="someVar1" type="xsd:string"
+                minOccurs="0" maxOccurs="unbounded"/>
+            </sequence>
+          </extension>
+        </complexContent>
+      </complexType>
+
+      <complexType name="DerivedClass2">
+        <complexContent>
+          <extension base="tns:BaseClass">
+            <sequence>
+              <element name="someVar2" type="xsd:string"
+                minOccurs="0" maxOccurs="unbounded"/>
+            </sequence>
+          </extension>
+        </complexContent>
+      </complexType>
+    </schema>
+  </wsdl:types>
+
+  <wsdl:message name="echoDerivedRequest">
+    <wsdl:part name="parameter" type="tns:BaseClass"/>
+  </wsdl:message>
+
+  <wsdl:message name="echoDerivedResponse">
+    <wsdl:part name="return" type="tns:BaseClass"/>
+  </wsdl:message>
+
+  <wsdl:portType name="extensionService">
+
+    <wsdl:operation name="echoDerived">
+      <wsdl:input message="tns:echoDerivedRequest" name="echoDerivedRequest"/>
+      <wsdl:output message="tns:echoDerivedResponse" name="echoDerivedResponse"/>
+    </wsdl:operation>
+  </wsdl:portType>
+
+  <wsdl:binding name="extensionServiceSoapBinding"
+    type="tns:extensionService">
+
+    <wsdlsoap:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+
+    <wsdl:operation name="echoDerived">
+      <wsdlsoap:operation style="rpc" soapAction=""/>
+      <wsdl:input name="echoDerivedRequest">
+        <wsdlsoap:body
+          encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"
+          namespace="urn:www.example.org:extension" use="encoded"/>
+      </wsdl:input>
+      <wsdl:output name="echoDerivedResponse">
+        <wsdlsoap:body
+          encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"
+          namespace="urn:www.example.org:extension" use="encoded"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+
+  <wsdl:service name="extensionServiceService">
+    <wsdl:port name="extensionService"
+      binding="tns:extensionServiceSoapBinding">
+      <wsdlsoap:address location="http://localhost:8080/"/>
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>


### PR DESCRIPTION
Constructors for subclasses inherit the parameters for their parent classes. If the ConstructorParamsDefaultToNull configuration option is used these should default to null as well.

This fixes #130.
