### PR TITLE
Improve comments generation

### DIFF
--- a/lib/Wsdl2PhpGenerator/PhpSource/PhpDocComment.php
+++ b/lib/Wsdl2PhpGenerator/PhpSource/PhpDocComment.php
@@ -94,46 +94,50 @@ class PhpDocComment
      */
     public function getSource()
     {
-        $ret = PHP_EOL . '/**' . PHP_EOL;
-
-        // TODO: Look over the generation and possible combinations
-
-        $lines = explode(PHP_EOL, $this->description);
-        foreach ($lines as $line) {
-            $ret .= ' * ' . trim($line) . PHP_EOL;
-        }
-
+        $description = '';
         if (strlen($this->description) > 0) {
-            $ret .= ' * ' . PHP_EOL;
+            $preDescription = trim($this->description);
+            $lines = explode(PHP_EOL, $preDescription);
+            foreach ($lines as $line) {
+                $description .= ' ' . trim('* ' . $line) . PHP_EOL;
+            }
         }
 
+        $tags = '';
         if (count($this->params) > 0) {
             foreach ($this->params as $param) {
-                $ret .= $param->getSource();
+                $tags .= $param->getSource();
             }
         }
         if (count($this->throws) > 0) {
             foreach ($this->throws as $throws) {
-                $ret .= $throws->getSource();
+                $tags .= $throws->getSource();
             }
         }
         if ($this->var != null) {
-            $ret .= $this->var->getSource();
+            $tags .= $this->var->getSource();
         }
         if ($this->package != null) {
-            $ret .= $this->package->getSource();
+            $tags .= $this->package->getSource();
         }
         if ($this->author != null) {
-            $ret .= $this->author->getSource();
+            $tags .= $this->author->getSource();
         }
         if ($this->access != null) {
-            $ret .= $this->access->getSource();
+            $tags .= $this->access->getSource();
         }
         if ($this->return != null) {
-            $ret .= $this->return->getSource();
+            $tags .= $this->return->getSource();
         }
 
-        $ret .= ' */' . PHP_EOL;
+        if (!empty($description) && !empty($tags)) {
+            $description .= ' *' . PHP_EOL;
+        }
+        $ret = $description . $tags;
+
+        if (!empty($ret)) {
+            $ret = PHP_EOL . '/**' . PHP_EOL . $ret . ' */' . PHP_EOL;
+        }
 
         return $ret;
     }

--- a/tests/Wsdl2PhpGenerator/Tests/Functional/CommentsGenerationTest.php
+++ b/tests/Wsdl2PhpGenerator/Tests/Functional/CommentsGenerationTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Wsdl2PhpGenerator\Tests\Functional;
+
+/**
+ * Test handling of comments generation
+ */
+class CommentsGenerationTest extends Wsdl2PhpGeneratorFunctionalTestCase
+{
+
+    protected function getWsdlPath()
+    {
+        return $this->fixtureDir . '/commentsgeneration/commentsgeneration.wsdl';
+    }
+
+    public function testMainClassExists()
+    {
+        $this->assertGeneratedClassExists('CommentsGeneration');
+        return new \ReflectionClass(new \CommentsGeneration());
+    }
+
+    public function testEmptyCommentWillNotBeGenerated()
+    {
+        $this->assertGeneratedClassExists('ToBe');
+        $paramClass = new \ReflectionClass(new \ToBe());
+        $this->assertFalse($paramClass->getDocComment());
+    }
+
+    /**
+     * @depends testMainClassExists
+     */
+    public function testNewLinesRemovedFromBordersOfDescription(\ReflectionClass $mainClass)
+    {
+        /* @var $method \ReflectionMethod */
+        $method = $mainClass->getMethod('ToBe');
+        $this->assertContains('/**
+     * To die, to sleep
+     *
+     * @param ToBe $parameters', $method->getDocComment());
+    }
+
+    /**
+     * @depends testMainClassExists
+     */
+    public function testThereIsNoNewLineAfterDescriptionByDefault(\ReflectionClass $mainClass)
+    {
+        $this->markTestIncomplete('Enable after generated classes will have docs');
+        $this->assertContains('
+     * And by opposing end them?
+     */', $mainClass->getDocComment());
+    }
+
+    /**
+     * @depends testMainClassExists
+     */
+    public function testThereIsNoNewLineAboveTagsSection(\ReflectionClass $mainClass)
+    {
+        $property = $mainClass->getProperty('classmap');
+        $this->assertContains('/**
+     * @var array', $property->getDocComment());
+    }
+}

--- a/tests/Wsdl2PhpGenerator/Tests/Functional/Wsdl2PhpGeneratorFunctionalTestCase.php
+++ b/tests/Wsdl2PhpGenerator/Tests/Functional/Wsdl2PhpGeneratorFunctionalTestCase.php
@@ -35,6 +35,12 @@ abstract class Wsdl2PhpGeneratorFunctionalTestCase extends PHPUnit_Framework_Tes
     protected $fixtureDir = 'tests/fixtures/wsdl';
 
     /**
+     * Storage of already generated classes from WSDL to avoid double delaring and fatals
+     * @var array
+     */
+    private static $generatedTestCases = array();
+
+    /**
      * @return string The path to the WSDL to generate code from.
      */
     abstract protected function getWsdlPath();
@@ -46,7 +52,16 @@ abstract class Wsdl2PhpGeneratorFunctionalTestCase extends PHPUnit_Framework_Tes
     {
     }
 
-    protected function setup()
+    protected function setUp()
+    {
+        $this->generateCode();
+    }
+
+    /**
+     * Generate code from provided WSDL once to avoid redeclare fatal errors.
+     * Individual test cases can update the configuration before generating.
+     */
+    protected function generateCode()
     {
         $class = new ReflectionClass($this);
         $this->outputDir = 'tests/generated/' . $class->getShortName();
@@ -57,6 +72,10 @@ abstract class Wsdl2PhpGeneratorFunctionalTestCase extends PHPUnit_Framework_Tes
         // We do not execute the code generation here to allow individual test cases
         // to update the configuration further before generating.
 
+        if (!empty(self::$generatedTestCases[$class->getShortName()])) {
+            return;
+        }
+
         // Clear output dir before starting.
         if (is_dir($this->outputDir)) {
             // Remove any generated code.
@@ -66,6 +85,7 @@ abstract class Wsdl2PhpGeneratorFunctionalTestCase extends PHPUnit_Framework_Tes
         // Generate the code.
         $this->generator->generate($this->config);
 
+        self::$generatedTestCases[$class->getShortName()] = true;
     }
 
     /**

--- a/tests/fixtures/wsdl/commentsgeneration/commentsgeneration.wsdl
+++ b/tests/fixtures/wsdl/commentsgeneration/commentsgeneration.wsdl
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<wsdl:definitions xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:tns="http://www.example.org/CommentsGeneration/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" name="CommentsGeneration" targetNamespace="http://www.example.org/CommentsGeneration/">
+  <wsdl:types>
+    <xsd:schema
+    	targetNamespace="http://www.example.org/CommentsGeneration/">
+ 	    <xsd:element name="ToBe">
+    		<xsd:complexType>
+    			<xsd:sequence>
+    			</xsd:sequence>
+    		</xsd:complexType>
+    	</xsd:element>
+    	<xsd:element name="ToBeResponse">
+    		<xsd:complexType>
+    			<xsd:sequence>
+    				<xsd:element name="prince" type="xsd:string"></xsd:element>
+    				<xsd:element name="hamlet" type="xsd:string">
+    					<xsd:annotation>
+    						<xsd:documentation>
+
+    							Son of the late King and nephew of the
+    							present King
+
+    						</xsd:documentation>
+    					</xsd:annotation>
+    				</xsd:element>
+    			</xsd:sequence>
+    		</xsd:complexType>
+    	</xsd:element>
+    </xsd:schema>
+  </wsdl:types>
+  <wsdl:message name="ToBeResponse">
+  	<wsdl:part name="parameters" element="tns:ToBeResponse"></wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="ToBeRequest">
+  	<wsdl:part name="parameters" element="tns:ToBe"></wsdl:part>
+  </wsdl:message>
+  <wsdl:portType name="CommentsGeneration">
+  	<wsdl:documentation>To be, or not to be, that is the question—
+Whether tis Nobler in the mind to suffer
+The Slings and Arrows of outrageous Fortune,
+Or to take Arms against a Sea of troubles,
+And by opposing end them?</wsdl:documentation>
+
+  	<wsdl:operation name="ToBe">
+  		<wsdl:documentation>
+	
+To die, to sleep
+	
+</wsdl:documentation>
+  		<wsdl:input message="tns:ToBeRequest"></wsdl:input>
+  		<wsdl:output message="tns:ToBeResponse"></wsdl:output>
+  	</wsdl:operation>
+  </wsdl:portType>
+  <wsdl:binding name="CommentsGenerationSOAP" type="tns:CommentsGeneration">
+    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="ToBe">
+      <soap:operation soapAction="http://www.example.org/CommentsGeneration/ToBe"/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:service name="CommentsGeneration">
+    <wsdl:port binding="tns:CommentsGenerationSOAP" name="CommentsGenerationSOAP">
+      <soap:address location="http://www.example.org/"/>
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>


### PR DESCRIPTION
- Avoid empty comments and unnecessary new line after description
- Add chained style to PhpDocComment setters and use em
- Test empty comments and excessive newlines not generated in comments
