### PR TITLE
Fixed autoload.php path.

### DIFF
--- a/wsdl2php.php
+++ b/wsdl2php.php
@@ -6,13 +6,10 @@ use Wsdl2PhpGenerator\Console\Application;
 use Wsdl2PhpGenerator\Console\GenerateCommand;
 use Wsdl2PhpGenerator\Generator;
 
-if (file_exists('vendor/autoload.php'))
-{
-	require 'vendor/autoload.php';
-}
-else
-{
-	require __DIR__ . '/../../autoload.php';
+if (file_exists('vendor/autoload.php')) {
+    require 'vendor/autoload.php';
+} else {
+    require __DIR__ . '/../../autoload.php';
 }
 
 $app = new Application('wsdl2php', '2.4.2');


### PR DESCRIPTION
Fixed path to composer autoloader. The path is incorrect when included in a composer.json from another project.
