### PR TITLE
Remove setAccess

### DIFF
--- a/src/Wsdl2PhpGenerator/ComplexType.php
+++ b/src/Wsdl2PhpGenerator/ComplexType.php
@@ -71,7 +71,6 @@ class ComplexType extends Type
         }
 
         $constructorComment = new PhpDocComment();
-        $constructorComment->setAccess(PhpDocElementFactory::getPublicAccess());
         $constructorSource = '';
         $constructorParameters = '';
         $accessors = array();
@@ -84,7 +83,6 @@ class ComplexType extends Type
 
                 if (!$member->getNullable()) {
                     $constructorComment->addParam(PhpDocElementFactory::getParam($type, $name, ''));
-                    $constructorComment->setAccess(PhpDocElementFactory::getPublicAccess());
                     $constructorParameters .= ', $' . $name;
                     if ($this->config->get('constructorParamsDefaultToNull')) {
                         $constructorParameters .= ' = null';
@@ -102,10 +100,8 @@ class ComplexType extends Type
             $comment = new PhpDocComment();
             $comment->setVar(PhpDocElementFactory::getVar($type, $name, ''));
             if ($this->config->get('createAccessors')) {
-                $comment->setAccess(PhpDocElementFactory::getProtectedAccess());
                 $var = new PhpVariable('protected', $name, 'null', $comment);
             } else {
-                $comment->setAccess(PhpDocElementFactory::getPublicAccess());
                 $var = new PhpVariable('public', $name, 'null', $comment);
             }
             $class->addVariable($var);
@@ -113,7 +109,6 @@ class ComplexType extends Type
             if (!$member->getNullable()) {
                 $constructorSource .= '  $this->' . $name . ' = $' . $name . ';' . PHP_EOL;
                 $constructorComment->addParam(PhpDocElementFactory::getParam($type, $name, ''));
-                $constructorComment->setAccess(PhpDocElementFactory::getPublicAccess());
                 $constructorParameters .= ', $' . $name;
                 if ($this->config->get('constructorParamsDefaultToNull')) {
                     $constructorParameters .= ' = null';

--- a/src/Wsdl2PhpGenerator/Service.php
+++ b/src/Wsdl2PhpGenerator/Service.php
@@ -101,7 +101,6 @@ class Service
         $comment = new PhpDocComment();
         $comment->addParam(PhpDocElementFactory::getParam('array', 'options', 'A array of config values'));
         $comment->addParam(PhpDocElementFactory::getParam('string', 'wsdl', 'The wsdl file to use'));
-        $comment->setAccess(PhpDocElementFactory::getPublicAccess());
 
         $source = '  foreach (self::$classmap as $key => $value) {
     if (!isset($options[\'classmap\'][$key])) {
@@ -119,7 +118,6 @@ class Service
         // Generate the classmap
         $name = 'classmap';
         $comment = new PhpDocComment();
-        $comment->setAccess(PhpDocElementFactory::getPrivateAccess());
         $comment->setVar(PhpDocElementFactory::getVar('array', $name, 'The defined classes'));
 
         $init = 'array(' . PHP_EOL;
@@ -140,7 +138,6 @@ class Service
             $name = Validator::validateOperation($operation->getName());
 
             $comment = new PhpDocComment($operation->getDescription());
-            $comment->setAccess(PhpDocElementFactory::getPublicAccess());
             $comment->setReturn(PhpDocElementFactory::getReturn($operation->getReturns(), ''));
 
             foreach ($operation->getParams() as $param => $hint) {


### PR DESCRIPTION
> I agree that using declaring method visibility using @access public
> in DocBlocks is obsolete. It is cruft from a over four year old
> project. As such I think it would be OK just to remove the calls to
> PhpDocComment->setAccess() from the codebase. As I see it there is
> no need to include a configuration option.
