### PR TITLE
Remove setAccess for comments as we already at php 5.x about 10 years

### DIFF
--- a/src/Wsdl2PhpGenerator/ComplexType.php
+++ b/src/Wsdl2PhpGenerator/ComplexType.php
@@ -71,7 +71,6 @@ class ComplexType extends Type
         }
 
         $constructorComment = new PhpDocComment();
-        $constructorComment->setAccess(PhpDocElementFactory::getPublicAccess());
         $constructorSource = '';
         $constructorParameters = '';
         $accessors = array();
@@ -84,7 +83,6 @@ class ComplexType extends Type
 
                 if (!$member->getNillable()) {
                     $constructorComment->addParam(PhpDocElementFactory::getParam($type, $name, ''));
-                    $constructorComment->setAccess(PhpDocElementFactory::getPublicAccess());
                     $constructorParameters .= ', $' . $name;
                     if ($this->config->getConstructorParamsDefaultToNull()) {
                         $constructorParameters .= ' = null';
@@ -101,14 +99,12 @@ class ComplexType extends Type
 
             $comment = new PhpDocComment();
             $comment->setVar(PhpDocElementFactory::getVar($type, $name, ''));
-            $comment->setAccess(PhpDocElementFactory::getPublicAccess());
             $var = new PhpVariable('public', $name, 'null', $comment);
             $class->addVariable($var);
 
             if (!$member->getNillable()) {
                 $constructorSource .= '  $this->' . $name . ' = $' . $name . ';' . PHP_EOL;
                 $constructorComment->addParam(PhpDocElementFactory::getParam($type, $name, ''));
-                $constructorComment->setAccess(PhpDocElementFactory::getPublicAccess());
                 $constructorParameters .= ', $' . $name;
                 if ($this->config->getConstructorParamsDefaultToNull()) {
                     $constructorParameters .= ' = null';

--- a/src/Wsdl2PhpGenerator/Service.php
+++ b/src/Wsdl2PhpGenerator/Service.php
@@ -101,7 +101,6 @@ class Service
         $comment = new PhpDocComment();
         $comment->addParam(PhpDocElementFactory::getParam('array', 'options', 'A array of config values'));
         $comment->addParam(PhpDocElementFactory::getParam('string', 'wsdl', 'The wsdl file to use'));
-        $comment->setAccess(PhpDocElementFactory::getPublicAccess());
 
         $source = '  foreach (self::$classmap as $key => $value) {
     if (!isset($options[\'classmap\'][$key])) {
@@ -119,7 +118,6 @@ class Service
         // Generate the classmap
         $name = 'classmap';
         $comment = new PhpDocComment();
-        $comment->setAccess(PhpDocElementFactory::getPrivateAccess());
         $comment->setVar(PhpDocElementFactory::getVar('array', $name, 'The defined classes'));
 
         $init = 'array(' . PHP_EOL;
@@ -140,7 +138,6 @@ class Service
             $name = Validator::validateOperation($operation->getName());
 
             $comment = new PhpDocComment($operation->getDescription());
-            $comment->setAccess(PhpDocElementFactory::getPublicAccess());
             $comment->setReturn(PhpDocElementFactory::getReturn($operation->getReturns(), ''));
 
             foreach ($operation->getParams() as $param => $hint) {


### PR DESCRIPTION
Btw, I think it will be ok to remove comments setAccess in 2.x branch:
- It's not related to interface
- You already told, that changes in generated code are not critical

So lets' remove 'em here too.
