### PR TITLE
Fix syntax error when service has no types

### DIFF
--- a/src/Wsdl2PhpGenerator/Service.php
+++ b/src/Wsdl2PhpGenerator/Service.php
@@ -128,7 +128,10 @@ class Service
                 $init .= "  '" . $type->getIdentifier() . "' => '" . $this->config->getNamespaceName() . "\\" . $type->getPhpIdentifier() . "'," . PHP_EOL;
             }
         }
-        $init = substr($init, 0, strrpos($init, ','));
+        $positionOfLastSemicolon = strrpos($init, ',');
+        if ($positionOfLastSemicolon != false) {
+            $init = substr($init, 0, $positionOfLastSemicolon);
+        }
         $init .= ')';
         $var = new PhpVariable('private static', $name, $init, $comment);
 


### PR DESCRIPTION
There was an error within the string handling, since strrpos evaluates to false, and false is interpreted by substr as a length of 0.

Fixes #162 
