### PR TITLE
Use proxy setting from SoapClient when loading XSDs

### DIFF
--- a/src/Wsdl2PhpGenerator/Config.php
+++ b/src/Wsdl2PhpGenerator/Config.php
@@ -71,7 +71,8 @@ class Config implements ConfigInterface
             'sharedTypes'                    => false,
             'constructorParamsDefaultToNull' => false,
             'soapClientClass'               => '\SoapClient',
-            'soapClientOptions'             => array()
+            'soapClientOptions'             => array(),
+            'proxy'                         => false
         ));
 
         $resolver->setNormalizers(array(
@@ -81,6 +82,70 @@ class Config implements ConfigInterface
                 }
 
                 return array_map('trim', explode(',', $value));
+            },
+            'proxy' => function(Options $options, $value) {
+                if (!$value) return false; // proxy setting is optional
+                if (is_string($value)) {
+                    $url_parts = parse_url($value);
+                    $proxy_array = array(
+                        'proxy_host' => $url_parts['host']
+                    );
+                    if (isset($url_parts['scheme'])) {
+                        $proxy_array['proxy_scheme'] = $url_parts['scheme'];
+                    }
+                    if (isset($url_parts['port'])) {
+                        $proxy_array['proxy_port'] = $url_parts['port'];
+                    }
+                    if (isset($url_parts['user'])) {
+                        $proxy_array['proxy_login'] = $url_parts['user'];
+                    }
+                    if (isset($url_parts['pass'])) {
+                        $proxy_array['proxy_password'] = $url_parts['pass'];
+                    }
+                    $value = $proxy_array;
+                } elseif (is_array($value)) {
+                    if (!array_key_exists('host', $value) && !array_key_exists('proxy_host', $value)) {
+                        throw new InvalidArgumentException(
+                            '"proxy" configuration setting must contain at least a key "host" or "proxy_host"'
+                        );
+                    }
+                    // normalize short keys ('host') to SoapClient config standard ('proxy_host')
+                    if (isset($value['host'])) {
+                        $value['proxy_host'] = $value['host'];
+                        unset($value['host']);
+                    }
+                    if (isset($value['port'])) {
+                        $value['proxy_port'] = $value['port'];
+                        unset($value['port']);
+                    }
+                    if (isset($value['login'])) {
+                        $value['proxy_login'] = $value['login'];
+                        unset($value['login']);
+                    }
+                    if (isset($value['password'])) {
+                        $value['proxy_password'] = $value['password'];
+                        unset($value['password']);
+                    }
+                } else {
+                    throw new InvalidArgumentException(
+                        '"proxy" configuration setting must be either a string containing the proxy url '
+                        . 'or an array containing at least a key "host" or "proxy_host"'
+                    );
+                }
+                if (!isset($value['proxy_port'])) {
+                    $value['proxy_port'] = 8080; // Default value of SoapClient
+                }
+                if (!is_int($value['proxy_port'])) {
+                    $value['proxy_port'] = intval($value['proxy_port']); // convert strings to integers for better testing
+                }
+                $value['proxy_url'] = (isset($value['proxy_scheme']) ? $value['proxy_scheme'] . '://' : '');
+                $value['proxy_url'] .= $value['proxy_host'] . ':' . $value['proxy_port'];
+                if (isset($value['proxy_login']) && isset($value['proxy_password'])) {
+                    $value['http_header_auth'] = array(
+                        'Proxy-Authorization: Basic ' . base64_encode($value['proxy_login'] . ':' . $value['proxy_password'])
+                    );
+                }
+                return $value;
             }
         ));
     }

--- a/src/Wsdl2PhpGenerator/Xml/WsdlDocument.php
+++ b/src/Wsdl2PhpGenerator/Xml/WsdlDocument.php
@@ -40,23 +40,14 @@ class WsdlDocument extends SchemaDocument
         // Otherwise we risk generating code for a WSDL that is no longer valid.
         $options = array_merge($this->config->get('soapClientOptions'), array('cache_wsdl' => WSDL_CACHE_NONE));
 
-
-        if (isset($options['proxy_host']) && $options['proxy_host']) {
-            $proxy = $options['proxy_host'];
-            if (isset($options['proxy_port']) && $options['proxy_port']) $proxy .= ':' . $options['proxy_port'];
-            $opts = array(
-                'http' => array(
-                    'proxy' => $proxy,
-                )
-            );
-            $context = stream_context_create($opts);
-            libxml_set_streams_context($context);
+        if (is_array($config->get('proxy'))) {
+            $options = array_merge($options, $config->get('proxy'));
         }
 
         try {
             $soapClientClass = new \ReflectionClass($this->config->get('soapClientClass'));
             $this->soapClient = $soapClientClass->newInstance($wsdlUrl, $options);
-            parent::__construct($wsdlUrl);
+            parent::__construct($config, $wsdlUrl); // we need to pass $config for proxy settings
         } catch (SoapFault $e) {
             throw new Exception('Unable to load WSDL: ' . $e->getMessage(), $e->getCode(), $e);
         }

--- a/tests/Wsdl2PhpGenerator/Tests/Unit/ConfigTest.php
+++ b/tests/Wsdl2PhpGenerator/Tests/Unit/ConfigTest.php
@@ -86,4 +86,79 @@ class ConfigTest extends PHPUnit_Framework_TestCase
             $this->assertEquals($config->get('classNames'), $expected);
         }
     }
+
+    /**
+     * Test the proxy normalizer
+     */
+    public function testProxyNormalizer()
+    {
+        $toTest = array(
+            array(
+                'in' => '192.168.0.1:8080',
+                'out' => array(
+                    'proxy_host' => '192.168.0.1',
+                    'proxy_port' => 8080,
+                    'proxy_url' => '192.168.0.1:8080'
+                )
+            ),
+            array(
+                'in' => 'tcp://192.168.0.1:8080',
+                'out' => array(
+                    'proxy_host' => '192.168.0.1',
+                    'proxy_port' => 8080,
+                    'proxy_url' => 'tcp://192.168.0.1:8080',
+                    'proxy_scheme' => 'tcp'
+                )
+            ),
+            array(
+                'in' => 'tcp://user:secret@192.168.0.1:8080',
+                'out' => array(
+                    'proxy_host' => '192.168.0.1',
+                    'proxy_port' => 8080,
+                    'proxy_url' => 'tcp://192.168.0.1:8080',
+                    'proxy_scheme' => 'tcp',
+                    'proxy_login' => 'user',
+                    'proxy_password' => 'secret',
+                    'http_header_auth' => array('Proxy-Authorization: Basic dXNlcjpzZWNyZXQ=')
+                )
+            ),
+            array(
+                'in' => array(
+                    'host' => '192.168.0.1',
+                    'port' => 8080
+                ),
+                'out' => array(
+                    'proxy_host' => '192.168.0.1',
+                    'proxy_port' => 8080,
+                    'proxy_url' => '192.168.0.1:8080'
+                )
+            ),
+            array(
+                'in' => array(
+                    'host' => '192.168.0.1',
+                    'port' => 8080,
+                    'login' => 'user',
+                    'password' => 'secret'
+                ),
+                'out' => array(
+                    'proxy_host' => '192.168.0.1',
+                    'proxy_port' => 8080,
+                    'proxy_url' => '192.168.0.1:8080',
+                    'proxy_login' => 'user',
+                    'proxy_password' => 'secret',
+                    'http_header_auth' => array('Proxy-Authorization: Basic dXNlcjpzZWNyZXQ=')
+                )
+            ),
+        );
+
+        foreach ($toTest as $testcase) {
+            $config = new Config(array(
+                'inputFile'  => null,
+                'outputDir'  => null,
+                'proxy' => $testcase['in']
+            ));
+
+            $this->assertEquals($config->get('proxy'), $testcase['out']);
+        }
+    }
 }


### PR DESCRIPTION
For the SoapClient, a proxy can be set using $config['soapClientOptions']['proxy_host'] and $config['soapClientOptions']['proxy_port'].
This patch uses those settings to configure the proxy in the libxml stream context for fetching the WSDL.

Resolves  #176 for the 3.x branch.
