### PR TITLE
Forcing getElementMinOccurs to return an int since it can be a string

### DIFF
--- a/src/Xml/TypeNode.php
+++ b/src/Xml/TypeNode.php
@@ -103,7 +103,7 @@ class TypeNode extends XmlNode
                 if ($minOccurs === '') {
                     return null;
                 }
-                return $minOccurs;
+                return (int) $minOccurs;
             }
         }
         return null;


### PR DESCRIPTION
Given that the use of getElementMinOccurs expects an int (with a check of === 0) then we must provide an int in all cases. When minOccurs is a string "0" the === 0 check in the generator will fail and it will consider it required.