### PR TITLE
Parsing DateTime values in depend of acceptable dateTime format in XML

### DIFF
--- a/src/ComplexType.php
+++ b/src/ComplexType.php
@@ -117,7 +117,11 @@ class ComplexType extends Type
                 $getterCode = '  if ($this->' . $name . ' == null) {' . PHP_EOL
                     . '    return null;' . PHP_EOL
                     . '  } else {' . PHP_EOL
-                    . '    return \DateTime::createFromFormat(\DateTime::ATOM, $this->' . $name . ');' . PHP_EOL
+                    . '    try {' . PHP_EOL
+                    . '      return new \DateTime($this->' . $name . ');' . PHP_EOL
+                    . '    } catch (\Exception $e) {' . PHP_EOL
+                    . '      return false;' . PHP_EOL
+                    . '    }' . PHP_EOL
                     . '  }' . PHP_EOL;
             } else {
                 $getterCode = '  return $this->' . $name . ';' . PHP_EOL;

--- a/tests/src/Unit/ComplexTypeTest.php
+++ b/tests/src/Unit/ComplexTypeTest.php
@@ -50,6 +50,19 @@ class ComplexTypeTest extends CodeGenerationTestCase
             'dateTimeAttribute',
             '\DateTime'
         );
+
+        // Using reflection to set up bad datetime value as like SoapClass does it
+        $property = 'dateTimeAttribute';
+        $badDateTime = 'noDate';
+        $this->setObjectProperty($object, $class, $property, $badDateTime);
+        $this->assertFalse($object->getDateTimeAttribute());
+
+        // Test passing variable datetime formats available in SOAP, http://www.w3.org/TR/2001/REC-xmlschema-2-20010502/#dateTime
+        $now = new \DateTime();
+        foreach (array('Y-m-d\TH:i:s', 'Y-m-d\TH:i:sP', 'Y-m-d\TH:i:s.u', 'Y-m-d\TH:i:s.uP', 'Y-m-d\TH:i:s\Z', 'Y-m-d\TH:i:s.u\Z') as $format) {
+            $this->setObjectProperty($object, $class, $property, $now->format($format));
+            $this->assertInstanceOf('\DateTime', $object->getDateTimeAttribute());
+        }
     }
 
     /**
@@ -155,4 +168,19 @@ class ComplexTypeTest extends CodeGenerationTestCase
       );
     }
 
+    /**
+     * Sets object property value using reflection
+     *
+     * @param mixed $object
+     * @param \ReflectionClass $class
+     * @param string $propertyName
+     * @param mixed $value
+     */
+    private function setObjectProperty($object, \ReflectionClass $class, $propertyName, $value)
+    {
+        $property = $class->getProperty($propertyName);
+        $property->setAccessible(true);
+        $property->setValue($object, $value);
+        $property->setAccessible(false);
+    }
 }


### PR DESCRIPTION
I've created another pull request with DateTime in ComplexType. 
There are more acceptable dateTime formats in SOAP responses (as in XML) that only \DateTime::ATOM is. 
Described here:
http://books.xmlschemata.org/relaxng/ch19-77049.html
or defined by W3C: http://www.w3.org/TR/2001/REC-xmlschema-2-20010502/#dateTime
I've replaced \DateTime::createFromFormat by only creating new \DateTime instance and catching expection. The unit-test is added shows how does it work.
The most problem is in timezone definition which is not required. I've added optional microseconds too.