### PR TITLE
Add option not to generate the autoloader.

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -72,9 +72,10 @@ class Config implements ConfigInterface
             'operationNames'                 => '',
             'sharedTypes'                    => false,
             'constructorParamsDefaultToNull' => false,
-            'soapClientClass'               => '\SoapClient',
-            'soapClientOptions'             => array(),
-            'proxy'                         => false
+            'soapClientClass'                => '\SoapClient',
+            'soapClientOptions'              => array(),
+            'proxy'                          => false,
+            'generateAutoloader'             => true,
         ));
 
         // A set of configuration options names and normalizer callables.

--- a/src/OutputManager.php
+++ b/src/OutputManager.php
@@ -53,8 +53,10 @@ class OutputManager
             $this->saveClassToFile($type);
         }
 
-        $classes = array_merge(array($service), $types);
-        $this->saveAutoloader($service->getIdentifier(), $classes);
+        if ($this->config->get('generateAutoloader')) {
+            $classes = array_merge(array($service), $types);
+            $this->saveAutoloader($service->getIdentifier(), $classes);
+        }
     }
 
     /**

--- a/tests/src/Functional/AutoloaderSkipTest.php
+++ b/tests/src/Functional/AutoloaderSkipTest.php
@@ -1,0 +1,26 @@
+<?php
+namespace Wsdl2PhpGenerator\Tests\Functional;
+
+class AutoloaderSkipTest extends FunctionalTestCase
+{
+    protected function getWsdlPath()
+    {
+        return $this->fixtureDir . '/abstract/abstract.wsdl';
+    }
+
+    /**
+     * Set the autoloader to not generate the autoloader.
+     */
+    protected function configureOptions()
+    {
+        $this->config->set('generateAutoloader', false);
+    }
+
+    /**
+     * Assert the autoloader was not created.
+     */
+    public function testRelativeImportPaths()
+    {
+        $this->assertFileNotGenerated('autoload.php');
+    }
+}

--- a/tests/src/Functional/AutoloaderTest.php
+++ b/tests/src/Functional/AutoloaderTest.php
@@ -1,0 +1,18 @@
+<?php
+namespace Wsdl2PhpGenerator\Tests\Functional;
+
+class AutoloaderTest extends FunctionalTestCase
+{
+    protected function getWsdlPath()
+    {
+        return $this->fixtureDir . '/abstract/abstract.wsdl';
+    }
+
+    /**
+     * Assert the autoloader was created with default config.
+     */
+    public function testRelativeImportPaths()
+    {
+        $this->assertGeneratedFileExists('autoload.php');
+    }
+}

--- a/tests/src/Functional/FunctionalTestCase.php
+++ b/tests/src/Functional/FunctionalTestCase.php
@@ -81,8 +81,11 @@ abstract class FunctionalTestCase extends CodeGenerationTestCase
 
         self::$generatedTestCases[$class->getShortName()] = true;
 
-        // Register the autoloader.
-        require_once $this->outputDir . DIRECTORY_SEPARATOR . 'autoload.php';
+        // Register the autoloader if it is generated.
+        $autoloaderPath = $this->outputDir . DIRECTORY_SEPARATOR . 'autoload.php';
+        if (file_exists($autoloaderPath)) {
+            require_once $autoloaderPath;
+        }
     }
 
     /**


### PR DESCRIPTION
Projects using their own loaders don't need an autoloader.

It can be disabled using:

``` php
$generator = new \Wsdl2PhpGenerator\Generator();
$generator->generate(
    new \Wsdl2PhpGenerator\Config(array(
        //...
        'generate_autoloader' => false,
    ))
);
```
