### PR TITLE
Create a class abstract when defined in the wsdl.

### DIFF
--- a/lib/PhpSource/PhpClass.php
+++ b/lib/PhpSource/PhpClass.php
@@ -79,13 +79,21 @@ class PhpClass extends PhpElement
 
     /**
      *
+     * @var bool If the class is abstract.
+     * @access private
+     */
+    private $abstract;
+
+    /**
+     *
      * @param string $identifier
      * @param bool $classExists
      * @param string $extends A string of the class that this class extends
      * @param PhpDocComment $comment
      * @param bool $final
+     * @param bool $abstract
      */
-    public function __construct($identifier, $classExists = false, $extends = '', PhpDocComment $comment = null, $final = false)
+    public function __construct($identifier, $classExists = false, $extends = '', PhpDocComment $comment = null, $final = false, $abstract = false)
     {
         $this->dependencies = array();
         $this->classExists = $classExists;
@@ -98,6 +106,7 @@ class PhpClass extends PhpElement
         $this->variables = array();
         $this->functions = array();
         $this->indentionStr = '    '; // Use 4 spaces as indention, as requested by PSR-2
+        $this->abstract = $abstract;
     }
 
     /**
@@ -125,6 +134,10 @@ class PhpClass extends PhpElement
 
         if ($this->final) {
             $ret .= 'final ';
+        }
+
+        if ($this->abstract) {
+            $ret .= 'abstract ';
         }
 
         $ret .= 'class ' . $this->identifier;

--- a/src/ComplexType.php
+++ b/src/ComplexType.php
@@ -36,6 +36,11 @@ class ComplexType extends Type
     private $members;
 
     /**
+     * @var
+     */
+    private $abstract;
+
+    /**
      * Construct the object
      *
      * @param ConfigInterface $config The configuration
@@ -46,6 +51,7 @@ class ComplexType extends Type
         parent::__construct($config, $name, null);
         $this->members = array();
         $this->baseType = null;
+        $this->abstract = false;
     }
 
     /**
@@ -62,7 +68,10 @@ class ComplexType extends Type
         $class = new PhpClass(
             $this->phpIdentifier,
             false,
-            $this->baseType !== null ? $this->baseType->getPhpIdentifier() : ''
+            $this->baseType !== null ? $this->baseType->getPhpIdentifier() : '',
+            null,
+            false,
+            $this->abstract
         );
 
         $constructorComment = new PhpDocComment();
@@ -182,6 +191,22 @@ class ComplexType extends Type
     public function setBaseType(ComplexType $type)
     {
         $this->baseType = $type;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getAbstract()
+    {
+        return $this->abstract;
+    }
+
+    /**
+     * @param bool $abstract
+     */
+    public function setAbstract($abstract)
+    {
+        $this->abstract = $abstract;
     }
 
     /**

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -142,6 +142,8 @@ class Generator implements GeneratorInterface
                 $type = new ComplexType($this->config, $typeNode->getName());
                 $this->log('Loading type ' . $type->getPhpIdentifier());
 
+                $type->setAbstract($typeNode->isAbstract());
+
                 foreach ($typeNode->getParts() as $name => $typeName) {
                     // There are 2 ways a wsdl can indicate that a field accepts the null value -
                     // by setting the "nillable" attribute to "true" or by setting the "minOccurs" attribute to "0".

--- a/src/Xml/TypeNode.php
+++ b/src/Xml/TypeNode.php
@@ -225,8 +225,19 @@ class TypeNode extends XmlNode
     {
         // If array is defied as inherited from array type it has restricton to array elements type, but still is complexType
         return
-            $this->restriction == 'struct' ||
-            $this->element->localName == 'complexType';
+          $this->restriction == 'struct' ||
+          $this->element->localName == 'complexType';
+    }
+
+    /**
+     * Returns whether the type is abstract.
+     *
+     * @return bool Whether the type is abstract.
+     */
+    public function isAbstract()
+    {
+        return $this->element->hasAttribute('abstract')
+            && $this->element->getAttribute('abstract') == 'true';
     }
 
     /**

--- a/tests/src/Functional/AbstractTest.php
+++ b/tests/src/Functional/AbstractTest.php
@@ -53,5 +53,14 @@ class AbstractTest extends FunctionalTestCase
         foreach ($subClassConstructor->getParameters() as $parameter) {
             $this->assertMethodHasParameter($subSubClassConstructor, $parameter, $parameter->getPosition());
         }
+
+    }
+
+    public function testAbstractClass()
+    {
+        $this->assertGeneratedClassExists('Author');
+        $abstractClass = new \ReflectionClass('Author');
+
+        $this->assertTrue($abstractClass->isAbstract());
     }
 }


### PR DESCRIPTION
It should not be possible to instantiate a class defined as abstract in the wsdl.