### PR TITLE
Nested complex types are not handled when allowed multiple times.

### DIFF
--- a/tests/fixtures/wsdl/abstract/abstract.wsdl
+++ b/tests/fixtures/wsdl/abstract/abstract.wsdl
@@ -87,6 +87,21 @@
           </extension>
         </complexContent>
       </complexType>
+
+      <element name="nestedComplexType">
+        <complexType>
+          <sequence>
+            <element maxOccurs="unbounded" minOccurs="0" name="entry">
+              <complexType>
+                <sequence>
+                  <element minOccurs="0" name="key" type="string"/>
+                </sequence>
+              </complexType>
+            </element>
+          </sequence>
+        </complexType>
+      </element>
+        
     </schema>
   </wsdl:types>
 

--- a/tests/src/Functional/AbstractTest.php
+++ b/tests/src/Functional/AbstractTest.php
@@ -54,4 +54,22 @@ class AbstractTest extends FunctionalTestCase
             $this->assertMethodHasParameter($subSubClassConstructor, $parameter, $parameter->getPosition());
         }
     }
+
+    public function testNestedComplexType()
+    {
+        $this->assertGeneratedClassExists('nestedComplexType');
+        $this->assertGeneratedClassExists('entry');
+
+        $class = new \ReflectionClass('nestedComplexType');
+
+        $this->assertTrue(
+            $class->getConstructor()->getParameters()[0]->isArray(),
+            'The constructor should be an array as the maxOccurs are set to unbound.'
+        );
+
+        $this->assertTrue(
+            $class->getMethod('setEntry')->getParameters()[0]->isArray(),
+            'The setter should accept an array as the maxOccurs are set to unbound.'
+        );
+    }
 }


### PR DESCRIPTION
When generating classes from a nested complex type, the input should be handled as an array but isn't.

I wrote a test as I can't quickly find where this is going wrong.
