### PR TITLE
Allow dots in wsdl function signatures

### DIFF
--- a/src/Xml/OperationNode.php
+++ b/src/Xml/OperationNode.php
@@ -48,7 +48,7 @@ class OperationNode extends DocumentedNode
         if (preg_match(
             // Look for definitions in the format:
             // return_type method_name(param_type1 param1, param_type2 param2)
-            '/^(\w[\w\d_]*) (\w[\w\d_]*)\(([\w\$\d,_ ]*)\)$/',
+            '/^(\w[\w\d_.]*) (\w[\w\d_]*)\(([\w\$\d,_. ]*)\)$/',
             $this->wsdlFunction,
             $matches
         )) {
@@ -57,7 +57,7 @@ class OperationNode extends DocumentedNode
             $this->params = $matches[3];
         } elseif (preg_match(
             // @TODO Document when this case is triggered and what the difference is to the case above.
-            '/^(list\([\w\$\d,_ ]*\)) (\w[\w\d_]*)\(([\w\$\d,_ ]*)\)$/',
+            '/^(list\([\w\$\d,_. ]*\)) (\w[\w\d_]*)\(([\w\$\d,_. ]*)\)$/',
             $this->wsdlFunction,
             $matches
         )) {


### PR DESCRIPTION
In some cases there is a need to work with complex types which names contain dots, for example:
`Some.Awesome.Namespace.Great.Class`.
Such types can appear in wsdl's generated by old-style Zend autodiscover libs (See https://github.com/zendframework/Component_ZendSoap/blob/release-2.1.2/Wsdl.php#L659 for example) or in case when server-side FQCN's are transformed in wsdl types by replacing `\` by `.`.

This patch allows dots in wsdl function signatures.