### PR TITLE
Allow constructor overloading without loss of default WSDL URL

### DIFF
--- a/src/Service.php
+++ b/src/Service.php
@@ -164,7 +164,7 @@ class Service implements ClassGenerator
   }' . PHP_EOL;
         $source .= '  $options = array_merge(' . var_export($this->config->get('soapClientOptions'), true) . ', $options);' . PHP_EOL;
         $source .= '  if(!$wsdl)' . PHP_EOL;
-        $source .= '    $wsdl = \'' . $this->config->get('inputFile') . '\'' . PHP_EOL;
+        $source .= '    $wsdl = \'' . $this->config->get('inputFile') . '\';' . PHP_EOL;
         $source .= '  parent::__construct($wsdl, $options);' . PHP_EOL;
 
         $function = new PhpFunction('public', '__construct', 'array $options = array(), $wsdl = \'\'', $source, $comment);

--- a/src/Service.php
+++ b/src/Service.php
@@ -163,9 +163,11 @@ class Service implements ClassGenerator
     }
   }' . PHP_EOL;
         $source .= '  $options = array_merge(' . var_export($this->config->get('soapClientOptions'), true) . ', $options);' . PHP_EOL;
+        $source .= '  if(!$wsdl)' . PHP_EOL;
+        $source .= '    $wsdl = \'' . $this->config->get('inputFile') . '\'' . PHP_EOL;
         $source .= '  parent::__construct($wsdl, $options);' . PHP_EOL;
 
-        $function = new PhpFunction('public', '__construct', 'array $options = array(), $wsdl = \'' . $this->config->get('inputFile') . '\'', $source, $comment);
+        $function = new PhpFunction('public', '__construct', 'array $options = array(), $wsdl = \'\'', $source, $comment);
 
         // Add the constructor
         $this->class->addFunction($function);


### PR DESCRIPTION
now:
```php
class foo extends Service {
     __constructor($options = [], $wsdl = ''){
        ....
        parent::__constructor($options, $wsdl); // loss of default URL
    }
}
```

from now on:
```php
class foo extends Service {
     __constructor($options = [], $wsdl = ''){
        ....
        parent::__constructor($options, $wsdl); // no loss of default URL
    }
}
```