### PR TITLE
Fixed issues with latest symphony throwing deprecated errors at runtime

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -58,7 +58,7 @@ class Config implements ConfigInterface
         return $this;
     }
 
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setRequired(array(
             'inputFile',
@@ -95,7 +95,10 @@ class Config implements ConfigInterface
                 return $normalizer->invokeArgs($object, func_get_args());
             };
         }, $normalizers);
-        $resolver->setNormalizers($normalizers);
+
+        foreach ($normalizers as $option => $normalizer) {
+            $resolver->setNormalizer($option, $normalizer);
+        }
     }
 
     /**


### PR DESCRIPTION
 - Updated configureOptions to use symphony’s new OptionsResolver instead of the deprecated interface
 - Updated the deprecated setNormalizers call to instead loop the normalizers and set them individually
 - Unit tests now pass
 - Example code in readme now works correctly