### PR TITLE
Update symfony dependencies to remove deprecation warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,9 @@ php:
   - 5.6
 
 env:
-  - SYMFONY_VERSION="~2.3"
-  # Test against previous minor releases of Symfony 2.x to ensure that we
-  # actually support the versions we specify in our requirements.
-  - SYMFONY_VERSION="2.3.*"
+  matrix:
+    - PREFER_LOWEST="--prefer-lowest"
+    - PREFER_LOWEST=""
 
 sudo: false
 
@@ -19,9 +18,7 @@ before_script:
   # rate limits resulting in 502 HTTP responses, build errors and
   # Composer\Downloader\TransportException.
   # https://github.com/symfony/symfony/issues/4687
-  - composer install --dev --no-interaction --prefer-source
-  # Update the Symfony version to test against.
-  - composer require symfony/options-resolver:${SYMFONY_VERSION}
+  - composer update --dev --no-interaction --prefer-source $PREFER_LOWEST
 
 script:
   - mkdir -p build/logs

--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,10 @@
     "require-dev": {
         "kasperg/phing-github": "0.2.*",
         "phing/phing": "~2.7",
-        "php-vcr/phpunit-testlistener-vcr": "1.1.*",
+        "php-vcr/php-vcr": "~1.2",
+        "php-vcr/phpunit-testlistener-vcr": "~1.1.2",
         "phpunit/phpunit": "~4.4",
-	"psr/log": "~1.0"
+        "psr/log": "~1.0",
+        "symfony/yaml": "~2.1"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=5.3.0",
         "ext-soap": "*",
-        "symfony/options-resolver": "~2.3"
+        "symfony/options-resolver": "~2.6"
     },
     "require-dev": {
         "kasperg/phing-github": "0.2.*",

--- a/src/Config.php
+++ b/src/Config.php
@@ -58,7 +58,7 @@ class Config implements ConfigInterface
         return $this;
     }
 
-    protected function configureOptions(OptionsResolverInterface $resolver)
+    protected function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setRequired(array(
             'inputFile',
@@ -95,7 +95,10 @@ class Config implements ConfigInterface
                 return $normalizer->invokeArgs($object, func_get_args());
             };
         }, $normalizers);
-        $resolver->setNormalizers($normalizers);
+
+        foreach ($normalizers as $option => $normalizer) {
+            $resolver->setNormalizer($option, $normalizer);
+        }
     }
 
     /**

--- a/tests/fixtures/vcr/CurrencyConverterTest_testCurrencyConvertor
+++ b/tests/fixtures/vcr/CurrencyConverterTest_testCurrencyConvertor
@@ -6,10 +6,12 @@
         headers:
             Host: www.webservicex.net
             Content-Type: 'text/xml; charset=utf-8; action="http://www.webserviceX.NET/ConversionRate"'
-            Content-Length: '326'
         body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SOAP-ENV:Envelope xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:ns1=\"http://www.webserviceX.NET/\"><SOAP-ENV:Body><ns1:ConversionRate><ns1:FromCurrency>USD</ns1:FromCurrency><ns1:ToCurrency>EUR</ns1:ToCurrency></ns1:ConversionRate></SOAP-ENV:Body></SOAP-ENV:Envelope>\n"
     response:
-        status: 200
+        status:
+            http_version: '1.1'
+            code: '200'
+            message: OK
         headers:
             Cache-Control: 'private, max-age=0'
             Content-Length: '382'
@@ -17,5 +19,5 @@
             Server: Microsoft-IIS/7.0
             X-AspNet-Version: 4.0.30319
             X-Powered-By: ASP.NET
-            Date: 'Wed, 23 Jul 2014 10:13:35 GMT'
-        body: '<?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><soap:Body><ConversionRateResponse xmlns="http://www.webserviceX.NET/"><ConversionRateResult>0.7426</ConversionRateResult></ConversionRateResponse></soap:Body></soap:Envelope>'
+            Date: 'Wed, 05 Aug 2015 17:48:18 GMT'
+        body: '<?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><soap:Body><ConversionRateResponse xmlns="http://www.webserviceX.NET/"><ConversionRateResult>0.9167</ConversionRateResult></ConversionRateResponse></soap:Body></soap:Envelope>'

--- a/tests/fixtures/vcr/NaicsTest_testNaics
+++ b/tests/fixtures/vcr/NaicsTest_testNaics
@@ -6,10 +6,12 @@
         headers:
             Host: www.webservicex.net
             Content-Type: 'text/xml; charset=utf-8; action="http://www.webservicex.net/GetNAICSByIndustry"'
-            Content-Length: '311'
         body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SOAP-ENV:Envelope xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:ns1=\"http://www.webservicex.net/\"><SOAP-ENV:Body><ns1:GetNAICSByIndustry><ns1:IndustryName>Computer Systems</ns1:IndustryName></ns1:GetNAICSByIndustry></SOAP-ENV:Body></SOAP-ENV:Envelope>\n"
     response:
-        status: 200
+        status:
+            http_version: '1.1'
+            code: '200'
+            message: OK
         headers:
             Cache-Control: 'private, max-age=0'
             Content-Length: '1987'
@@ -17,5 +19,5 @@
             Server: Microsoft-IIS/7.0
             X-AspNet-Version: 4.0.30319
             X-Powered-By: ASP.NET
-            Date: 'Wed, 23 Jul 2014 10:13:52 GMT'
+            Date: 'Wed, 05 Aug 2015 17:48:20 GMT'
         body: '<?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><soap:Body><GetNAICSByIndustryResponse xmlns="http://www.webservicex.net/"><GetNAICSByIndustryResult>true</GetNAICSByIndustryResult><NAICSData><Records>3</Records><NAICSData><NAICS><NAICSCode>5415</NAICSCode><Title>Computer Systems Design and Related Services</Title><Country /><IndustryDescription>See industry description for 54151 below.</IndustryDescription></NAICS><NAICS><NAICSCode>54151</NAICSCode><Title>Computer Systems Design and Related Services</Title><Country /><IndustryDescription>This industry comprises establishments primarily engaged in providing expertise in the field of information technologies through one or more of the following activities: (1) writing, modifying, testing, and supporting software to meet the needs of a particular customer; (2) planning and designing computer systems that integrate computer hardware, software, and communication technologies; (3) on-site management and operation of clients'' computer systems and/or data processing facilities; and (4) other professional and technical computer-related advice and services.</IndustryDescription></NAICS><NAICS><NAICSCode>541512</NAICSCode><Title>Computer Systems Design Services</Title><Country>US</Country><IndustryDescription>This U.S. industry comprises establishments primarily engaged in planning and designing computer systems that integrate computer hardware, software, and communication technologies. The hardware and software components of the system may be provided by this establishment or company as part of integrated services or may be provided by third parties or vendors. These establishments often install the system and train and support users of the system.</IndustryDescription></NAICS></NAICSData></NAICSData></GetNAICSByIndustryResponse></soap:Body></soap:Envelope>'

--- a/tests/fixtures/vcr/NaicsTest_testSingleNaics
+++ b/tests/fixtures/vcr/NaicsTest_testSingleNaics
@@ -6,10 +6,12 @@
         headers:
             Host: www.webservicex.net
             Content-Type: 'text/xml; charset=utf-8; action="http://www.webservicex.net/GetNAICSByID"'
-            Content-Length: '282'
         body: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SOAP-ENV:Envelope xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:ns1=\"http://www.webservicex.net/\"><SOAP-ENV:Body><ns1:GetNAICSByID><ns1:NAICSCode>54151</ns1:NAICSCode></ns1:GetNAICSByID></SOAP-ENV:Body></SOAP-ENV:Envelope>\n"
     response:
-        status: 200
+        status:
+            http_version: '1.1'
+            code: '200'
+            message: OK
         headers:
             Cache-Control: 'private, max-age=0'
             Content-Length: '1164'
@@ -17,5 +19,5 @@
             Server: Microsoft-IIS/7.0
             X-AspNet-Version: 4.0.30319
             X-Powered-By: ASP.NET
-            Date: 'Sat, 15 Nov 2014 20:56:14 GMT'
+            Date: 'Wed, 05 Aug 2015 17:48:20 GMT'
         body: '<?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><soap:Body><GetNAICSByIDResponse xmlns="http://www.webservicex.net/"><GetNAICSByIDResult>true</GetNAICSByIDResult><NAICSData><Records>1</Records><NAICSData><NAICS><NAICSCode>54151</NAICSCode><Title>Computer Systems Design and Related Services</Title><Country /><IndustryDescription>This industry comprises establishments primarily engaged in providing expertise in the field of information technologies through one or more of the following activities: (1) writing, modifying, testing, and supporting software to meet the needs of a particular customer; (2) planning and designing computer systems that integrate computer hardware, software, and communication technologies; (3) on-site management and operation of clients'' computer systems and/or data processing facilities; and (4) other professional and technical computer-related advice and services.</IndustryDescription></NAICS></NAICSData></NAICSData></GetNAICSByIDResponse></soap:Body></soap:Envelope>'


### PR DESCRIPTION
This is a continuation of #225.

This should fix the build and update the way we test against multiple versions of our dependencies.