### PR TITLE
Allows run tests on Windows

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -6,5 +6,5 @@ use \VCR\VCR;
 require_once __DIR__ . '/../vendor/autoload.php';
 
 VCR::configure()
-  ->setCassettePath('tests/fixtures/vcr');
+  ->setCassettePath(__DIR__ . '/fixtures/vcr');
 VCR::turnOn();

--- a/tests/src/Functional/CommentsGenerationTest.php
+++ b/tests/src/Functional/CommentsGenerationTest.php
@@ -36,7 +36,7 @@ class CommentsGenerationTest extends FunctionalTestCase
         $this->assertContains('/**
      * To die, to sleep
      *
-     * @param ToBe $parameters', $method->getDocComment());
+     * @param ToBe $parameters', $this->normalizeEOL($method->getDocComment()));
     }
 
     /**
@@ -47,7 +47,7 @@ class CommentsGenerationTest extends FunctionalTestCase
         $this->markTestIncomplete('Enable after generated classes will have docs');
         $this->assertContains('
      * And by opposing end them?
-     */', $mainClass->getDocComment());
+     */', $this->normalizeEOL($mainClass->getDocComment()));
     }
 
     /**
@@ -57,6 +57,21 @@ class CommentsGenerationTest extends FunctionalTestCase
     {
         $property = $mainClass->getProperty('classmap');
         $this->assertContains('/**
-     * @var array', $property->getDocComment());
+     * @var array', $this->normalizeEOL($property->getDocComment()));
+    }
+
+    /**
+     * Normalizes the newline.
+     *
+     * Windows uses CR+LF for the newline.
+     * This method converts the newline to UNIX style.
+     *
+     * @param string $string
+     *
+     * @return string
+     */
+    private function normalizeEOL($string)
+    {
+        return str_replace("\r", '', $string);
     }
 }

--- a/tests/src/Functional/FunctionalTestCase.php
+++ b/tests/src/Functional/FunctionalTestCase.php
@@ -29,7 +29,7 @@ abstract class FunctionalTestCase extends CodeGenerationTestCase
      */
     protected $config;
 
-    protected $fixtureDir = 'tests/fixtures/wsdl';
+    protected $fixtureDir;
 
     /**
      * Storage of already generated classes from WSDL to avoid double declaring and fatals
@@ -51,8 +51,11 @@ abstract class FunctionalTestCase extends CodeGenerationTestCase
 
     protected function setup()
     {
+        $testsDir = realpath(__DIR__ . '/../..');
+
         $class = new ReflectionClass($this);
-        $this->outputDir = 'tests/generated/' . $class->getShortName();
+        $this->outputDir = $testsDir . '/generated/' . $class->getShortName();
+        $this->fixtureDir = $testsDir . '/fixtures/wsdl';
         $this->generator = new Generator();
         $this->config = new Config(array(
             'inputFile' => $this->getWsdlPath(),


### PR DESCRIPTION
Adds minor changes to allow to run tests on Windows.

First, the relative paths is not issue of Windows, but using absolute paths we can use build-in tests runner of PHPStorm IDE.

The code generators used `PHP_EOL` constant, and a value of this constant is different between operation systems. So, we need to fix line endings to pass tests.