### PR TITLE
Added a fix for specifying stream context options

### DIFF
--- a/docs/whats-new-in-3.0.md
+++ b/docs/whats-new-in-3.0.md
@@ -57,7 +57,7 @@ For discussion and pull request see issues [#106](https://github.com/wsdl2phpgen
 
 Some configuration options provided in wsdl2phpgenerator 2.x were related to configuration of the PHP SoapClient. Not all SoapClient options were supported and this was the cause of many pull requests.
 
-In 3.0 there is now one generic configuration option `soapClientOptions` which accepts an array and passes it along to [the `SoapClient` constructor](http://php.net/manual/en/soapclient.soapclient.php). Thus wsdl2phpgenerator now supports all configuration options supported by the SOAP client class.
+In 3.0 there is now one generic configuration option `soapClientOptions` which accepts an array and passes it along to [the `SoapClient` constructor](http://php.net/manual/en/soapclient.soapclient.php). Thus wsdl2phpgenerator now supports all configuration options supported by the SOAP client class. One exception to this is the `stream_context` option, which should be configured using the `streamContextOptions` configuration. If you do specify the `stream_context` option, you will get an exception explaining this.
 
 Consequently the following configuration options have been removed.
 
@@ -66,6 +66,24 @@ Consequently the following configuration options have been removed.
 * `compression`
 
 For discussion and pull request see issues [#105](https://github.com/wsdl2phpgenerator/wsdl2phpgenerator/issues/105) and [#154](https://github.com/wsdl2phpgenerator/wsdl2phpgenerator/issues/154).
+
+### Configuring the stream context ###
+
+You can specify the stream context options using the `streamContextOptions` configuration parameter. This is especially useful for SSL configurations, such as ciphers, or local certificate validation, etc:
+ 
+```php
+new Wsdl2PhpGenerator\Config([
+    /* ... */
+    'streamContextOptions' => [
+        'ssl' => [
+            /* SSL specific context options here */
+        ]
+    ]
+    /* ... */
+])
+```
+
+Note that if you also specify the `stream_context` option as part of the `soapClientOptions`, you will get an exception. 
 
 ## Generated code
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -74,6 +74,7 @@ class Config implements ConfigInterface
             'constructorParamsDefaultToNull' => false,
             'soapClientClass'               => '\SoapClient',
             'soapClientOptions'             => array(),
+            'streamContextOptions'          => array(),
             'proxy'                         => false
         ));
 

--- a/src/StreamContextFactory.php
+++ b/src/StreamContextFactory.php
@@ -18,14 +18,22 @@ class StreamContextFactory
      */
     public function create(ConfigInterface $config)
     {
-        $options = array();
+        $streamContextOptions = $config->get('streamContextOptions');
+        $soapOptions = $config->get('soapClientOptions');
+
+        if (isset($soapOptions['stream_context'])) {
+            throw new \UnexpectedValueException("Please use the 'streamContextOptions' setting to configure the soap client stream context.");
+        }
         $headers = array();
 
         $proxy = $config->get('proxy');
         if (is_array($proxy)) {
-            $options = array(
-                'http' => array(
-                    'proxy' => $proxy['proxy_host'] . ':' . $proxy['proxy_port']
+            $streamContextOptions = array_merge_recursive(
+                $streamContextOptions,
+                array(
+                    'http' => array(
+                        'proxy' => $proxy['proxy_host'] . ':' . $proxy['proxy_port']
+                    )
                 )
             );
             if (isset($proxy['proxy_login']) && isset($proxy['proxy_password'])) {
@@ -36,7 +44,6 @@ class StreamContextFactory
             }
         }
 
-        $soapOptions = $config->get('soapClientOptions');
 
         if ((!isset($soapOptions['authentication']) || $soapOptions['authentication'] === SOAP_AUTHENTICATION_BASIC) &&
             isset($soapOptions['login']) &&
@@ -47,9 +54,9 @@ class StreamContextFactory
         }
 
         if (count($headers) > 0) {
-            $options['http']['header'] = $headers;
+            $streamContextOptions['http']['header'] = $headers;
         }
 
-        return stream_context_create($options);
+        return stream_context_create($streamContextOptions);
     }
 }

--- a/src/Xml/WsdlDocument.php
+++ b/src/Xml/WsdlDocument.php
@@ -40,6 +40,11 @@ class WsdlDocument extends SchemaDocument
         // Otherwise we risk generating code for a WSDL that is no longer valid.
         $options = array_merge($this->config->get('soapClientOptions'), array('cache_wsdl' => WSDL_CACHE_NONE));
 
+        $streamContextOptions = $this->config->get('streamContextOptions');
+        if (!empty($streamContextOptions)) {
+            $options['stream_context'] = stream_context_create($streamContextOptions);
+        }
+
         try {
             $soapClientClass = new \ReflectionClass($this->config->get('soapClientClass'));
             $this->soapClient = $soapClientClass->newInstance($wsdlUrl, $options);

--- a/tests/src/Unit/StreamContextFactoryTest.php
+++ b/tests/src/Unit/StreamContextFactoryTest.php
@@ -114,4 +114,93 @@ class StreamContextFactoryTest extends \PHPUnit_Framework_TestCase
         $header = 'Proxy-Authorization: Basic ' . base64_encode($proxy['login'] . ':' . $proxy['password']);
         $this->assertContains($header, $options['http']['header']);
     }
+
+
+    /**
+     * Test that the stream context options cannot be specified for the soap client class.
+     *
+     * @expectedException \UnexpectedValueException
+     */
+    public function testSpecifyingBothSoapStreamContextAndStreamContextOptionsWillResultInError()
+    {
+        $config = new Config(array(
+            'inputFile' => null,
+            'outputDir' => null,
+            'streamContextOptions' => array(
+                'ssl' => array(
+                    'ciphers' => 'ABC'
+                )
+            ),
+            'soapClientOptions' => array(
+                'stream_context' => stream_context_create()
+            )
+        ));
+
+        $factory = new StreamContextFactory();
+        $resource = $factory->create($config);
+        $options = stream_context_get_options($resource);
+
+        $this->assertArrayHasKey('ssl', $options);
+    }
+
+
+    /**
+     * Test that the stream context options are propagated to the factory's context creation
+     */
+    public function testStreamContextOptions()
+    {
+        $config = new Config(array(
+            'inputFile' => null,
+            'outputDir' => null,
+            'streamContextOptions' => array(
+                'ssl' => array(
+                    'ciphers' => 'ABC'
+                )
+            )
+        ));
+
+        $factory = new StreamContextFactory();
+        $resource = $factory->create($config);
+        $options = stream_context_get_options($resource);
+
+        $this->assertArrayHasKey('ssl', $options);
+    }
+
+    /**
+     * Test that the stream context options are merged if a proxy configuration is applicable
+     */
+    public function testStreamContextOptionsAreMerged()
+    {
+        $soapOptions = array(
+            'login' => 'user',
+            'password' => 'secret'
+        );
+        $proxy = array(
+            'host' => '192.168.0.1',
+            'port' => 8080,
+            'login' => 'proxy-user',
+            'password' => 'proxy-secret',
+        );
+        $config = new Config(array(
+            'inputFile' => null,
+            'outputDir' => null,
+            'soapClientOptions' => $soapOptions,
+            'proxy' => $proxy,
+            'streamContextOptions' => array(
+                'ssl' => array(
+                    'ciphers' => 'foo'
+                )
+            )
+        ));
+
+        $factory = new StreamContextFactory();
+        $resource = $factory->create($config);
+
+        $options = stream_context_get_options($resource);
+
+        $this->assertArrayHasKey('http', $options);
+        $this->assertArrayHasKey('proxy', $options['http']);
+        $this->assertArrayHasKey('ssl', $options);
+        $this->assertArrayHasKey('ciphers', $options['ssl']);
+    }
 }


### PR DESCRIPTION
SoapClient now reuses context options specified in config. Fixes issue #261