### PR TITLE
Fix build on PHP 5.3 and 5.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require-dev": {
         "kasperg/phing-github": "0.2.*",
         "phing/phing": "~2.7",
-        "php-vcr/php-vcr": "~1.2",
+        "php-vcr/php-vcr": "1.2 - 1.2.7",
         "php-vcr/phpunit-testlistener-vcr": "~1.1.2",
         "phpunit/phpunit": "~4.4",
         "psr/log": "~1.0",


### PR DESCRIPTION
We see segfaults when running tests on PHP 5.3 and 5.4. This may be 
caused by errors upstream. To avoid this we set upper bound on 
dependencies to the latest known successful build.