### PR TITLE
Support for UTF8 on operations/types names.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
     "require": {
         "php": ">=5.3.0",
         "ext-soap": "*",
-        "symfony/options-resolver": "~2.6"
+        "symfony/options-resolver": "~2.6",
+        "ext-iconv": "*"
     },
     "require-dev": {
         "kasperg/phing-github": "0.2.*",

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -290,6 +290,8 @@ class Validator
      */
     private static function validateNamingConvention($name)
     {
+        $name = iconv("UTF-8", "ASCII//TRANSLIT", $name);
+
         // Prepend the string a to names that begin with anything but a-z This is to make a valid name
         if (preg_match('/^[A-Za-z_]/', $name) == false) {
             $name = self::NAME_PREFIX . ucfirst($name);

--- a/src/Xml/OperationNode.php
+++ b/src/Xml/OperationNode.php
@@ -48,7 +48,7 @@ class OperationNode extends DocumentedNode
         if (preg_match(
             // Look for definitions in the format:
             // return_type method_name(param_type1 param1, param_type2 param2)
-            '/^(\w[\w\d_.]*) (\w[\w\d_]*)\(([\w\$\d,_. ]*)\)$/',
+            '/^(\w[\w\d_.]*) (\w[\w\d_]*)\(([\w\$\d,_. ]*)\)$/u',
             $this->wsdlFunction,
             $matches
         )) {
@@ -57,7 +57,7 @@ class OperationNode extends DocumentedNode
             $this->params = $matches[3];
         } elseif (preg_match(
             // @TODO Document when this case is triggered and what the difference is to the case above.
-            '/^(list\([\w\$\d,_. ]*\)) (\w[\w\d_]*)\(([\w\$\d,_. ]*)\)$/',
+            '/^(list\([\w\$\d,_. ]*\)) (\w[\w\d_]*)\(([\w\$\d,_. ]*)\)$/u',
             $this->wsdlFunction,
             $matches
         )) {

--- a/tests/fixtures/wsdl/abstract/abstract.wsdl
+++ b/tests/fixtures/wsdl/abstract/abstract.wsdl
@@ -66,6 +66,14 @@
         </sequence>
       </complexType>
 
+      <complexType name="MsgContraseña">
+        <sequence>
+          <element name="id" type="xsd:unsignedInt" minOccurs="1"
+            maxOccurs="1"/>
+        </sequence>
+      </complexType>
+
+
       <complexType name="DerivedClass1">
         <complexContent>
           <extension base="tns:BaseClass">
@@ -115,6 +123,15 @@
     <wsdl:part name="return" type="tns:BaseClass"/>
   </wsdl:message>
 
+
+  <wsdl:message name="validarContraseñaRequest">
+    <wsdl:part name="parameter" type="tns:MsgContraseña"/>
+  </wsdl:message>
+
+  <wsdl:message name="validarContraseñaResponse">
+    <wsdl:part name="return" type="tns:MsgContraseña"/>
+  </wsdl:message>
+
   <wsdl:portType name="AbstractService">
     <wsdl:operation name="echo" parameterOrder="obj typename">
       <wsdl:input message="tns:echoRequest" name="echoRequest"/>
@@ -130,6 +147,12 @@
       <wsdl:input message="tns:echoDerivedRequest" name="echoDerivedRequest"/>
       <wsdl:output message="tns:echoDerivedResponse" name="echoDerivedResponse"/>
     </wsdl:operation>
+
+    <wsdl:operation name="validarContraseña">
+      <wsdl:input message="tns:validarContraseñaRequest" name="validarContraseñaRequest"/>
+      <wsdl:output message="tns:validarContraseñaResponse" name="validarContraseñaResponse"/>
+    </wsdl:operation>
+
   </wsdl:portType>
 
   <wsdl:binding name="AbstractServiceSoapBinding"
@@ -174,6 +197,21 @@
           namespace="urn:www.example.org:abstract" use="encoded"/>
       </wsdl:output>
     </wsdl:operation>
+
+    <wsdl:operation name="validarContraseña">
+      <wsdlsoap:operation style="rpc" soapAction=""/>
+      <wsdl:input name="validarContraseñaRequest">
+        <wsdlsoap:body
+          encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"
+          namespace="urn:www.example.org:abstract" use="encoded"/>
+      </wsdl:input>
+      <wsdl:output name="validarContraseñaResponse">
+        <wsdlsoap:body
+          encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"
+          namespace="urn:www.example.org:abstract" use="encoded"/>
+      </wsdl:output>
+    </wsdl:operation>
+
   </wsdl:binding>
 
   <wsdl:service name="AbstractServiceService">

--- a/tests/src/Functional/AbstractTest.php
+++ b/tests/src/Functional/AbstractTest.php
@@ -21,11 +21,22 @@ class AbstractTest extends FunctionalTestCase
         // AbstractServiceService contains an operation called echo. This is a PHP keyword and should thus have been
         // renamed in the generation process to avoid conflicts.
         $serviceClass = new \ReflectionClass('AbstractServiceService');
+
         $methods = array_map(function (\ReflectionMethod $method) {
             return $method->getName();
         }, $serviceClass->getMethods());
         $this->assertNotContains('echo', $methods, 'Class should not contain a method called echo. It is a reserved keyword');
         $this->assertContains('aEcho', $methods, 'Class should contain a method with a derived name for echo since it is a reserved keyword');
+
+        // Validate UTF8 names on opeartions
+        $this->assertContains('validarContrasena', $methods, 'Class should contain a method from an UToperation name, translited');
+
+        // Valid file name for UTF8 named type
+        $this->assertGeneratedFileExists('MsgContrasena.php');
+
+        // Valid class name for UTF8 named type
+        $this->assertGeneratedClassExists('MsgContrasena');
+
 
         // Complex types UserAuthor and NonUserAuthor extends the User type. That relationship should be converted to
         // subclasses in the generated code.
@@ -53,6 +64,8 @@ class AbstractTest extends FunctionalTestCase
         foreach ($subClassConstructor->getParameters() as $parameter) {
             $this->assertMethodHasParameter($subSubClassConstructor, $parameter, $parameter->getPosition());
         }
+
+
 
     }
 


### PR DESCRIPTION
We have found that webservices serving operation names with "ñ" or other utf8 characters, don't get recognized as an OperationNode, so the method don't show up on the main service class.

"/u" modifier is needed in order to achieve this.

After these, those characters, simply would disappear from file or class names... 
Using iconv to convert from UTF-8 to ASCII//TRANSLIT would make files names, methods and class names more readable.


