### PR TITLE
Fixed schema referencing when generating code from multiple WSDL files referencing previously loaded XSDs

### DIFF
--- a/src/Xml/SchemaDocument.php
+++ b/src/Xml/SchemaDocument.php
@@ -31,12 +31,12 @@ class SchemaDocument extends XmlNode
      *
      * @var SchemaDocument[]
      */
-    protected $referereces;
+    protected $references;
 
     /**
      * The urls of schemas which have already been loaded.
      *
-     * We keep a record of these to avoid cyclic imports.
+     * We keep a record of these to avoid cyclical imports.
      *
      * @var string[]
      */
@@ -58,14 +58,14 @@ class SchemaDocument extends XmlNode
         }
 
         parent::__construct($document, $document->documentElement);
-        // Register the schema to avoid cyclic imports.
-        self::$loadedUrls[] = $xsdUrl;
+        // Register the schema to avoid cyclical imports.
+        self::$loadedUrls[$xsdUrl] = $this;
 
         // Locate and instantiate schemas which are referenced by the current schema.
         // A reference in this context can either be
         // - an import from another namespace: http://www.w3.org/TR/xmlschema-1/#composition-schemaImport
         // - an include within the same namespace: http://www.w3.org/TR/xmlschema-1/#compound-schema
-        $this->referereces = array();
+        $this->references = array();
         foreach ($this->xpath(  '//wsdl:import/@location|' .
                                 '//s:import/@schemaLocation|' .
                                 '//s:include/@schemaLocation') as $reference) {
@@ -74,8 +74,11 @@ class SchemaDocument extends XmlNode
                 $referenceUrl = dirname($xsdUrl) . '/' . $referenceUrl;
             }
 
-            if (!in_array($referenceUrl, self::$loadedUrls)) {
-                $this->referereces[] = new SchemaDocument($config, $referenceUrl);
+            if (!array_key_exists($referenceUrl, self::$loadedUrls)) {
+                $this->references[] = new SchemaDocument($config, $referenceUrl);
+            } else {
+                // Refer to the previously loaded schema.
+                $this->references[] = self::$loadedUrls[$referenceUrl];
             }
         }
     }
@@ -88,6 +91,18 @@ class SchemaDocument extends XmlNode
      */
     public function findTypeElement($name)
     {
+        return $this->findTypeElementFromSchema($name);
+    }
+
+    /**
+     * Parses the schema for a type with a specific name. Checks whether imports have been checked before, to
+     * circumvent endless loops.
+     *
+     * @param string $name The name of the type.
+     * @param SchemaDocument[] $checkedImports
+     * @return \DOMNode|null Returns the type node with the provided if it is found. Null otherwise.
+     */
+    private function findTypeElementFromSchema($name, array &$checkedImports = array()) {
         $type = null;
 
         $elements = $this->xpath('//s:simpleType[@name=%s]|//s:complexType[@name=%s]', $name, $name);
@@ -96,8 +111,12 @@ class SchemaDocument extends XmlNode
         }
 
         if (empty($type)) {
-            foreach ($this->referereces as $import) {
-                $type = $import->findTypeElement($name);
+            foreach ($this->references as $import) {
+                if (in_array($import, $checkedImports)) {
+                    continue;
+                }
+                $checkedImports[] = $import;
+                $type = $import->findTypeElementFromSchema($name, $checkedImports);
                 if (!empty($type)) {
                     break;
                 }


### PR DESCRIPTION
When code is generated from multiple WSDL files which share common XSD files, only the first WSDL would contain the right references to the used XSD files. This is due to the fact that no references were set in the constructor of the SchemaDocument class when the referenced XSD file was previously loaded.

This patch creates a link between the referenced XSD url and the initialized SchemaDocument and will set the used references correctly when the XSD was already loaded. Also makes sure that schemas referring to each other won't result in endless loops in SchemaDocument::findTypeElement.