### PR TITLE
Adding a singleton method so that this can be called by the wsdl2phpg…

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -50,12 +50,28 @@ class Generator implements GeneratorInterface
     protected $logger;
 
     /**
+     * @var Generator 
+     */
+    protected static $_instance;
+
+    /**
      * Construct the generator
      */
     public function __construct()
     {
         $this->service = null;
         $this->types = array();
+    }
+
+    /**
+     * Singleton
+     * @return Generator class instance
+     */
+    public static function getInstance() {
+        if (!( self::$_instance instanceof self)) {
+            self::$_instance = new self();
+        }
+        return self::$_instance;
     }
 
     /**


### PR DESCRIPTION
I cloned the wsdl2phpgenerator/wsdl2phpgenerator-cli project and ran into the the following fatal error when attempting to execute:

> Fatal error: Call to undefined method Wsdl2PhpGenerator\Generator::getInstance() in ...\wsdl2phpgenerator-cli\wsdl2php.php on line 13

This patch fixes the error by adding a singleton to the Generator class.