### PR TITLE
Make Service Code Generation More Extensible

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -9,6 +9,7 @@ use \Exception;
 use Psr\Log\LoggerInterface;
 use Wsdl2PhpGenerator\Filter\FilterFactory;
 use Wsdl2PhpGenerator\Xml\WsdlDocument;
+use Wsdl2PhpGenerator\Xml\ServiceNode;
 
 /**
  * Class that contains functionality for generating classes from a wsdl file
@@ -114,10 +115,10 @@ class Generator implements GeneratorInterface
      */
     protected function loadService()
     {
-        $service = $this->wsdl->getService();
-        $this->log('Starting to load service ' . $service->getName());
+        $definition = $this->wsdl->getService();
+        $this->log('Starting to load service ' . $definition->getName());
 
-        $this->service = new Service($this->config, $service->getName(), $this->types, $service->getDocumentation());
+        $this->service = $this->createServiceFor($definition);
 
         foreach ($this->wsdl->getOperations() as $function) {
             $this->log('Loading function ' . $function->getName());
@@ -125,7 +126,24 @@ class Generator implements GeneratorInterface
             $this->service->addOperation(new Operation($function->getName(), $function->getParams(), $function->getDocumentation(), $function->getReturns()));
         }
 
-        $this->log('Done loading service ' . $service->getName());
+        $this->log('Done loading service ' . $definition->getName());
+    }
+
+    /**
+     * Create a new service object for the given service defnition node. This
+     * is provided so subclasses may override it to create custom service objects.
+     *
+     * @param $definition The service node from a WSDL
+     * @return Service a newly crate service object
+     */
+    protected function createServiceFor(ServiceNode $definition)
+    {
+        return new Service(
+            $this->config,
+            $definition->getName(),
+            $this->types,
+            $definition->getDocumentation()
+        );
     }
 
     /**

--- a/src/Service.php
+++ b/src/Service.php
@@ -141,6 +141,7 @@ class Service implements ClassGenerator
     public function generateClass()
     {
         $this->class = $this->createPhpClass();
+        $this->class->addVariable($this->createClassmapVariable());
 
         // Create the constructor
         $comment = new PhpDocComment();
@@ -163,22 +164,6 @@ class Service implements ClassGenerator
 
         // Add the constructor
         $this->class->addFunction($function);
-
-        // Generate the classmap
-        $name = 'classmap';
-        $comment = new PhpDocComment();
-        $comment->setVar(PhpDocElementFactory::getVar('array', $name, 'The defined classes'));
-
-        $init = array();
-        foreach ($this->types as $type) {
-            if ($type instanceof ComplexType) {
-                $init[$type->getIdentifier()] = $this->getConfigValue('namespaceName') . "\\" . $type->getPhpIdentifier();
-            }
-        }
-        $var = new PhpVariable('private static', $name, var_export($init, true), $comment);
-
-        // Add the classmap variable
-        $this->class->addVariable($var);
 
         // Add all methods
         foreach ($this->getOperations() as $operation) {
@@ -266,5 +251,26 @@ class Service implements ClassGenerator
     protected function getServiceParentClass()
     {
         return $this->getConfigValue('soapClientClass');
+    }
+
+    /**
+     * Create the classmap static variable for the generated serivce class.
+     *
+     * @return PhpVariable
+     */
+    protected function createClassmapVariable()
+    {
+        $name = 'classmap';
+        $comment = new PhpDocComment();
+        $comment->setVar(PhpDocElementFactory::getVar('array', $name, 'The defined classes'));
+
+        $init = array();
+        foreach ($this->types as $type) {
+            if ($type instanceof ComplexType) {
+                $init[$type->getIdentifier()] = $this->getConfigValue('namespaceName') . "\\" . $type->getPhpIdentifier();
+            }
+        }
+
+        return new PhpVariable('private static', $name, var_export($init, true), $comment);
     }
 }

--- a/src/Service.php
+++ b/src/Service.php
@@ -75,7 +75,7 @@ class Service implements ClassGenerator
     public function getClass()
     {
         if ($this->class == null) {
-            $this->generateClass();
+            $this->class = $this->generateClass();
         }
 
         return $this->class;
@@ -140,16 +140,18 @@ class Service implements ClassGenerator
      */
     public function generateClass()
     {
-        $this->class = $this->createPhpClass();
-        $this->class->addVariable($this->createClassmapVariable());
-        $this->class->addFunction($this->createConstructor());
+        $class = $this->createPhpClass();
+        $class->addVariable($this->createClassmapVariable());
+        $class->addFunction($this->createConstructor());
 
         foreach ($this->getOperations() as $operation) {
             $func = $this->createOperationMethod($operation);
-            if (!$this->class->functionExists($func->getIdentifier())) {
-                $this->class->addFunction($func);
+            if (!$class->functionExists($func->getIdentifier())) {
+                $class->addFunction($func);
             }
         }
+
+        return $class;
     }
 
     /**

--- a/src/Service.php
+++ b/src/Service.php
@@ -124,6 +124,7 @@ class Service implements ClassGenerator
     {
         return isset($this->types[$identifier])? $this->types[$identifier]: null;
     }
+
     /**
      * Returns all types defined by the service.
      *

--- a/src/Service.php
+++ b/src/Service.php
@@ -140,17 +140,7 @@ class Service implements ClassGenerator
      */
     public function generateClass()
     {
-        $name = $this->identifier;
-
-        // Generate a valid classname
-        $name = Validator::validateClass($name, $this->getConfigValue('namespaceName'));
-
-        // uppercase the name
-        $name = ucfirst($name);
-
-        // Create the class object
-        $comment = new PhpDocComment($this->description);
-        $this->class = new PhpClass($name, false, $this->getConfigValue('soapClientClass'), $comment);
+        $this->class = $this->createPhpClass();
 
         // Create the constructor
         $comment = new PhpDocComment();
@@ -243,5 +233,38 @@ class Service implements ClassGenerator
     protected function getConfigValue($key)
     {
         return $this->config->get($key);
+    }
+
+    /**
+     * Create a `PhpClass` object representing the service. This is used as part
+     * of the code generation.
+     *
+     * @return PhpClass
+     */
+    protected function createPhpClass()
+    {
+        // Generate a valid classname
+        $name = Validator::validateClass($this->getIdentifier(), $this->getConfigValue('namespaceName'));
+
+        // uppercase the name
+        $name = ucfirst($name);
+
+        // Create the class object
+        return  new PhpClass(
+            $name,
+            false,
+            $this->getServiceParentClass(),
+            new PhpDocComment($this->getDescription())
+        );
+    }
+
+    /**
+     * Get the parent class for the generated service.
+     *
+     * @return string
+     */
+    protected function getServiceParentClass()
+    {
+        return $this->getConfigValue('soapClientClass');
     }
 }

--- a/src/Service.php
+++ b/src/Service.php
@@ -142,14 +142,14 @@ class Service implements ClassGenerator
         $name = $this->identifier;
 
         // Generate a valid classname
-        $name = Validator::validateClass($name, $this->config->get('namespaceName'));
+        $name = Validator::validateClass($name, $this->getConfigValue('namespaceName'));
 
         // uppercase the name
         $name = ucfirst($name);
 
         // Create the class object
         $comment = new PhpDocComment($this->description);
-        $this->class = new PhpClass($name, false, $this->config->get('soapClientClass'), $comment);
+        $this->class = new PhpClass($name, false, $this->getConfigValue('soapClientClass'), $comment);
 
         // Create the constructor
         $comment = new PhpDocComment();
@@ -162,9 +162,9 @@ class Service implements ClassGenerator
       $options[\'classmap\'][$key] = $value;
     }
   }' . PHP_EOL;
-        $source .= '  $options = array_merge(' . var_export($this->config->get('soapClientOptions'), true) . ', $options);' . PHP_EOL;
+        $source .= '  $options = array_merge(' . var_export($this->getConfigValue('soapClientOptions'), true) . ', $options);' . PHP_EOL;
         $source .= '  if (!$wsdl) {' . PHP_EOL;
-        $source .= '    $wsdl = \'' . $this->config->get('inputFile') . '\';' . PHP_EOL;
+        $source .= '    $wsdl = \'' . $this->getConfigValue('inputFile') . '\';' . PHP_EOL;
         $source .= '  }' . PHP_EOL;
         $source .= '  parent::__construct($wsdl, $options);' . PHP_EOL;
 
@@ -181,7 +181,7 @@ class Service implements ClassGenerator
         $init = array();
         foreach ($this->types as $type) {
             if ($type instanceof ComplexType) {
-                $init[$type->getIdentifier()] = $this->config->get('namespaceName') . "\\" . $type->getPhpIdentifier();
+                $init[$type->getIdentifier()] = $this->getConfigValue('namespaceName') . "\\" . $type->getPhpIdentifier();
             }
         }
         $var = new PhpVariable('private static', $name, var_export($init, true), $comment);
@@ -221,5 +221,16 @@ class Service implements ClassGenerator
     public function addOperation(Operation $operation)
     {
         $this->operations[$operation->getName()] = $operation;
+    }
+
+    /**
+     * get a value out of the configuration.
+     *
+     * @param string $key The configuration key to look up
+     * @return mixed
+     */
+    protected function getConfigValue($key)
+    {
+        return $this->config->get($key);
     }
 }

--- a/src/Service.php
+++ b/src/Service.php
@@ -190,7 +190,7 @@ class Service implements ClassGenerator
         $this->class->addVariable($var);
 
         // Add all methods
-        foreach ($this->operations as $operation) {
+        foreach ($this->getOperations() as $operation) {
             $name = Validator::validateOperation($operation->getName());
 
             $comment = new PhpDocComment($operation->getDescription());
@@ -221,6 +221,16 @@ class Service implements ClassGenerator
     public function addOperation(Operation $operation)
     {
         $this->operations[$operation->getName()] = $operation;
+    }
+
+    /**
+     * Get all the operations registered with the service.
+     *
+     * @return Operation[]
+     */
+    public function getOperations()
+    {
+        return $this->operations;
     }
 
     /**

--- a/src/Service.php
+++ b/src/Service.php
@@ -229,14 +229,29 @@ class Service implements ClassGenerator
         $comment = new PhpDocComment();
         $comment->setVar(PhpDocElementFactory::getVar('array', $name, 'The defined classes'));
 
+        return new PhpVariable(
+            'private static',
+            $name,
+            var_export($this->typesToClassmap(), true),
+            $comment
+        );
+    }
+
+    /**
+     * Transform the `types` property into something suitable for a classmap.
+     *
+     * @return array
+     */
+    protected function typesToClassmap()
+    {
         $init = array();
-        foreach ($this->types as $type) {
+        foreach ($this->getTypes() as $type) {
             if ($type instanceof ComplexType) {
                 $init[$type->getIdentifier()] = $this->getConfigValue('namespaceName') . "\\" . $type->getPhpIdentifier();
             }
         }
 
-        return new PhpVariable('private static', $name, var_export($init, true), $comment);
+        return $init;
     }
 
     /**

--- a/src/Service.php
+++ b/src/Service.php
@@ -142,28 +142,7 @@ class Service implements ClassGenerator
     {
         $this->class = $this->createPhpClass();
         $this->class->addVariable($this->createClassmapVariable());
-
-        // Create the constructor
-        $comment = new PhpDocComment();
-        $comment->addParam(PhpDocElementFactory::getParam('array', 'options', 'A array of config values'));
-        $comment->addParam(PhpDocElementFactory::getParam('string', 'wsdl', 'The wsdl file to use'));
-
-        $source = '
-  foreach (self::$classmap as $key => $value) {
-    if (!isset($options[\'classmap\'][$key])) {
-      $options[\'classmap\'][$key] = $value;
-    }
-  }' . PHP_EOL;
-        $source .= '  $options = array_merge(' . var_export($this->getConfigValue('soapClientOptions'), true) . ', $options);' . PHP_EOL;
-        $source .= '  if (!$wsdl) {' . PHP_EOL;
-        $source .= '    $wsdl = \'' . $this->getConfigValue('inputFile') . '\';' . PHP_EOL;
-        $source .= '  }' . PHP_EOL;
-        $source .= '  parent::__construct($wsdl, $options);' . PHP_EOL;
-
-        $function = new PhpFunction('public', '__construct', 'array $options = array(), $wsdl = null', $source, $comment);
-
-        // Add the constructor
-        $this->class->addFunction($function);
+        $this->class->addFunction($this->createConstructor());
 
         // Add all methods
         foreach ($this->getOperations() as $operation) {
@@ -272,5 +251,31 @@ class Service implements ClassGenerator
         }
 
         return new PhpVariable('private static', $name, var_export($init, true), $comment);
+    }
+
+    /**
+     * Create the constructor for the generated service class.
+     *
+     * @return PhpFunction
+     */
+    protected function createConstructor()
+    {
+        $comment = new PhpDocComment();
+        $comment->addParam(PhpDocElementFactory::getParam('array', 'options', 'A array of config values'));
+        $comment->addParam(PhpDocElementFactory::getParam('string', 'wsdl', 'The wsdl file to use'));
+
+        $source = '
+  foreach (self::$classmap as $key => $value) {
+    if (!isset($options[\'classmap\'][$key])) {
+      $options[\'classmap\'][$key] = $value;
+    }
+  }' . PHP_EOL;
+        $source .= '  $options = array_merge(' . var_export($this->getConfigValue('soapClientOptions'), true) . ', $options);' . PHP_EOL;
+        $source .= '  if (!$wsdl) {' . PHP_EOL;
+        $source .= '    $wsdl = \'' . $this->getConfigValue('inputFile') . '\';' . PHP_EOL;
+        $source .= '  }' . PHP_EOL;
+        $source .= '  parent::__construct($wsdl, $options);' . PHP_EOL;
+
+        return new PhpFunction('public', '__construct', 'array $options = array(), $wsdl = null', $source, $comment);
     }
 }


### PR DESCRIPTION
I had the pleasure of generating some PHP classes for an AdWords API today and ran into some issues. This pull addresses some of those.

Specifically, I needed my service classes to extend a different soap client class than the one provided as the `soapClientClass` option (which gets used to fetch the WSDL). Mostly this is converting a bunch of existing code to more of a [template method](https://en.wikipedia.org/wiki/Template_method_pattern) pattern because I ended up having to subclass `Service` then copy the entirety of its body to make things work.

Summary:

- Provide getters in the `Service` class to subclasses can access the private properties
- Refactor `Service::generateClass` to more of a template method, where each part is its own individual method. While this looks like a lot of changes, it was just moving code around.
- Add the protected method `Generator::createServiceFor(ServiceNode $definition)`. This lets folks subclass the generator and return a custom service class easily. I was able to return a load a custom service class in `loadService`, but I had to copy the entire method to keep the operation loading intact.

A lot of this would be better solved with other patterns (visitor for the code generation, having a factory for the service objects, etc), but I figured this was the best way to maintain backwards compatibility.