### PR TITLE
Recursive types lead to error memory overflow

### DIFF
--- a/src/Filter/ServiceOperationFilter.php
+++ b/src/Filter/ServiceOperationFilter.php
@@ -111,6 +111,9 @@ class ServiceOperationFilter implements FilterInterface
             if (!$memberType) {
                 continue;
             }
+            if (in_array($memberType, $foundTypes)) {
+                continue;
+            }
 
             $foundTypes = array_merge($foundTypes, $this->findUsedTypes($service, $memberType));
         }


### PR DESCRIPTION
For example:

```
	 <xs:complexType name="NsiElementType">
		<xs:sequence>
			<xs:element name="Code" type="tns:nsiCodeType"/>
			<xs:element name="NsiElementField" type="tns:NsiElementFieldType" minOccurs="0" maxOccurs="unbounded"/>
			<xs:element name="ChildElement" type="tns:NsiElementType" minOccurs="0" maxOccurs="unbounded"/>
		</xs:sequence>
	</xs:complexType>
```