### PR TITLE
add option to make all properties public 

### DIFF
--- a/src/ComplexType.php
+++ b/src/ComplexType.php
@@ -104,7 +104,8 @@ class ComplexType extends Type
 
             $comment = new PhpDocComment();
             $comment->setVar(PhpDocElementFactory::getVar($type, $name, ''));
-            $var = new PhpVariable('protected', $name, 'null', $comment);
+            $access = $this->config->get('publicProperties') ? 'public' : 'protected';
+            $var = new PhpVariable($access, $name, 'null', $comment);
             $this->class->addVariable($var);
 
             if (!$member->getNullable()) {

--- a/src/Config.php
+++ b/src/Config.php
@@ -72,6 +72,7 @@ class Config implements ConfigInterface
             'operationNames'                 => '',
             'sharedTypes'                    => false,
             'constructorParamsDefaultToNull' => false,
+            'publicProperties'               => false,
             'soapClientClass'               => '\SoapClient',
             'soapClientOptions'             => array(),
             'proxy'                         => false


### PR DESCRIPTION
I understand that public properties where removed for a good reason, but for people who are upgrading from the old versions it would be a huge task to change all the calls that used to use public properties. 

On the other hand it's very easy to support an option to keep the properties as public (still keeping the accessor functions). That's what this pull request does.
The option is false by default.
