### PR TITLE
Php 5.4+ array notation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ vendor
 tests/generated
 TAG_MESSAGE
 composer.lock
+.idea/

--- a/src/Config.php
+++ b/src/Config.php
@@ -75,7 +75,7 @@ class Config implements ConfigInterface
             'soapClientClass'               => '\SoapClient',
             'soapClientOptions'             => array(),
             'proxy'                         => false,
-            'php7Arrays'                    => false
+            'bracketedArrays'               => false
         ));
 
         // A set of configuration options names and normalizer callables.

--- a/src/Config.php
+++ b/src/Config.php
@@ -74,7 +74,8 @@ class Config implements ConfigInterface
             'constructorParamsDefaultToNull' => false,
             'soapClientClass'               => '\SoapClient',
             'soapClientOptions'             => array(),
-            'proxy'                         => false
+            'proxy'                         => false,
+			'php7Arrays'					=> false
         ));
 
         // A set of configuration options names and normalizer callables.

--- a/src/Config.php
+++ b/src/Config.php
@@ -75,7 +75,7 @@ class Config implements ConfigInterface
             'soapClientClass'               => '\SoapClient',
             'soapClientOptions'             => array(),
             'proxy'                         => false,
-			'php7Arrays'					=> false
+            'php7Arrays'                    => false
         ));
 
         // A set of configuration options names and normalizer callables.

--- a/src/Service.php
+++ b/src/Service.php
@@ -134,23 +134,23 @@ class Service implements ClassGenerator
         return $this->types;
     }
 
-	/**
-	 * @param $content
-	 *
-	 * @return mixed
-	 */
-	protected function adjustArrayNotation($content)
-	{
-		return $this->config->get('php7Arrays')? str_replace(['array (', ')'], ['[', ']'], $content): $content;
-	}
+    /**
+     * @param $content
+     *
+     * @return mixed
+     */
+    protected function adjustArrayNotation($content)
+    {
+        return $this->config->get('php7Arrays')? str_replace(['array (', ')'], ['[', ']'], $content): $content;
+    }
 
     /**
      * Generates the class if not already generated
      */
     public function generateClass()
     {
-    	$arrayPrefix = $this->config->get('php7Arrays')? '[': 'array(';
-		$arraySuffix = $this->config->get('php7Arrays')? ']': ')';
+        $arrayPrefix = $this->config->get('php7Arrays')? '[': 'array(';
+        $arraySuffix = $this->config->get('php7Arrays')? ']': ')';
 
         $name = $this->identifier;
 

--- a/src/Service.php
+++ b/src/Service.php
@@ -141,7 +141,7 @@ class Service implements ClassGenerator
      */
     protected function adjustArrayNotation($content)
     {
-        return $this->config->get('php7Arrays')? str_replace(['array (', ')'], ['[', ']'], $content): $content;
+        return $this->config->get('bracketedArrays')? str_replace(['array (', ')'], ['[', ']'], $content): $content;
     }
 
     /**
@@ -149,8 +149,8 @@ class Service implements ClassGenerator
      */
     public function generateClass()
     {
-        $arrayPrefix = $this->config->get('php7Arrays')? '[': 'array(';
-        $arraySuffix = $this->config->get('php7Arrays')? ']': ')';
+        $arrayPrefix = $this->config->get('bracketedArrays')? '[': 'array(';
+        $arraySuffix = $this->config->get('bracketedArrays')? ']': ')';
 
         $name = $this->identifier;
 


### PR DESCRIPTION
This small push will allow wsdl2phpgenerator to render arrays using the bracket notation. I was originally calling it "php7Arrays", but since this feature is available since version 5.4, I renamed the configuration option to 'bracketedArrays': when set to true (the default is false, to preserve backward compatibility), all the arrays created inside the Service class will use the new bracket notation.