### PR TITLE
Pump php-vcr version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require-dev": {
         "kasperg/phing-github": "0.2.*",
         "phing/phing": "~2.7",
-        "php-vcr/php-vcr": "1.2 - 1.2.7",
+        "php-vcr/php-vcr": "1.2 - 1.2.7|^1.3.1",
         "php-vcr/phpunit-testlistener-vcr": "~1.1.2",
         "phpunit/phpunit": "~4.4",
         "psr/log": "~1.0",


### PR DESCRIPTION
php-vcr has fixed the issue regarding the segmentation fault for PHP 5.3 and 5.4:
https://github.com/php-vcr/php-vcr/releases/tag/1.3.1

I've added an extra version constraint for ^1.3

Hope it helps to keep things up to date!

build with the new version:
https://travis-ci.org/wsdl2phpgenerator/wsdl2phpgenerator/jobs/171179619#L188

build with the old version: (prefer lowest)
https://travis-ci.org/wsdl2phpgenerator/wsdl2phpgenerator/jobs/171179618#L188