### PR TITLE
add custom http header parameter to stream context

### DIFF
--- a/src/StreamContextFactory.php
+++ b/src/StreamContextFactory.php
@@ -49,6 +49,19 @@ class StreamContextFactory
         if (count($headers) > 0) {
             $options['http']['header'] = $headers;
         }
+		
+		 if(isset($soapOptions["stream_context"])){
+        	$clientStreamContext =  $soapOptions["stream_context"];
+        	$clientStreamContextOptions = stream_context_get_options($clientStreamContext);
+              if(isset($clientStreamContextOptions['http']['header'])){
+              	if(isset($options['http']['header'])){
+              		$options['http']['header'] .= '/r/n'.$clientStreamContextOptions['http']['header'];
+              	}else{
+              		$options['http']['header'] = $clientStreamContextOptions['http']['header'];
+              	}
+              }
+        }
+
 
         return stream_context_create($options);
     }


### PR DESCRIPTION
Add custom http header to stream context. In previous version  , stream
context is created  only  for Basic Authorization . But some wsdl
providers need  custom http header paramaters expect basic
authrorization. In this case , we can't get wsdl  by url. correctly.
For solving this problem , if there is stream_context in soapOption , we
merge into exist options