### PR TITLE
classPrefix option

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,6 @@ The directory to place the generated classes in. It will be created if it does n
 
 The [namespace](http://php.net/manual/en/language.namespaces.php) to use for the generated classes. If not set classes will be generated without a namespace.
 
-
 ##### Example usage
 
 The following configuration will place generated code from the [CDYNE Weather web service](http://wiki.cdyne.com/?title=CDYNE_Weather) under the `CDyne\Weather` namespace:
@@ -113,6 +112,14 @@ $generator->generate(
     ))
 );
 ```
+
+#### `classPrefix`
+
+A class prefix to use for all classes (eg: `My_Module_Which_Does_Not_Support_Namespaces_`).
+
+#### `baseClass`
+
+A base class name that all classes will extend (for types that extend another type, only the base one will extend this one).
 
 #### `classNames`
 

--- a/lib/PhpSource/PhpClass.php
+++ b/lib/PhpSource/PhpClass.php
@@ -90,6 +90,13 @@ class PhpClass extends PhpElement
      * @access private
      */
     private $abstract;
+    
+    /**
+     *
+     * @var string class prefix
+     * @access private
+     */
+    private $prefix;
 
     /**
      *
@@ -100,7 +107,7 @@ class PhpClass extends PhpElement
      * @param bool $final
      * @param bool $abstract
      */
-    public function __construct($identifier, $classExists = false, $extends = '', PhpDocComment $comment = null, $final = false, $abstract = false)
+    public function __construct($identifier, $classExists = false, $extends = '', PhpDocComment $comment = null, $final = false, $abstract = false, $prefix = '')
     {
         $this->dependencies = array();
         $this->classExists = $classExists;
@@ -114,6 +121,7 @@ class PhpClass extends PhpElement
         $this->functions = array();
         $this->indentionStr = '    '; // Use 4 spaces as indention, as requested by PSR-2
         $this->abstract = $abstract;
+        $this->prefix = $prefix;
     }
 
     /**
@@ -147,7 +155,7 @@ class PhpClass extends PhpElement
             $ret .= 'abstract ';
         }
 
-        $ret .= 'class ' . $this->identifier;
+        $ret .= 'class ' . $this->getPrefix() . $this->identifier;
 
         if (strlen($this->extends) > 0) {
             $ret .= ' extends ' . $this->extends;
@@ -310,5 +318,10 @@ class PhpClass extends PhpElement
     public function functionExists($identifier)
     {
         return array_key_exists($identifier, $this->functions);
+    }
+    
+    public function getPrefix()
+    {
+      return (string)$this->prefix;
     }
 }

--- a/src/ComplexType.php
+++ b/src/ComplexType.php
@@ -65,15 +65,18 @@ class ComplexType extends Type
             throw new Exception("The class has already been generated");
         }
 
-        $classBaseType = $this->getBaseTypeClass();
+        if  (!($baseClass = $this->getBaseTypeClass())) {
+          $baseClass = $this->baseClass;
+        }
 
         $this->class = new PhpClass(
             $this->phpIdentifier,
             false,
-            $classBaseType,
+            $baseClass,
             null,
             false,
-            $this->abstract
+            $this->abstract,
+            $this->classPrefix
         );
 
         $constructorComment = new PhpDocComment();

--- a/src/Config.php
+++ b/src/Config.php
@@ -74,7 +74,9 @@ class Config implements ConfigInterface
             'constructorParamsDefaultToNull' => false,
             'soapClientClass'               => '\SoapClient',
             'soapClientOptions'             => array(),
-            'proxy'                         => false
+            'proxy'                         => false,
+            'classPrefix'                   => '',
+            'baseClass'                     => '',
         ));
 
         // A set of configuration options names and normalizer callables.

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -46,7 +46,7 @@ class Enum extends Type
             throw new Exception("The class has already been generated");
         }
 
-        $this->class = new PhpClass($this->phpIdentifier, false);
+        $this->class = new PhpClass($this->phpIdentifier, false, $this->baseClass, null, false, false, $this->classPrefix);
 
         $first = true;
 

--- a/src/Filter/ServiceOperationFilter.php
+++ b/src/Filter/ServiceOperationFilter.php
@@ -58,9 +58,10 @@ class ServiceOperationFilter implements FilterInterface
             // Discover types used in returns
             $returns = $operation->getReturns();
             $methodTypes[] = $service->getType($returns);
-
             foreach ($methodTypes as $type) {
-                $methodTypes = array_merge($methodTypes, $this->findUsedTypes($service, $type)) ;
+                if ($type !== null) {
+                    $methodTypes = array_merge($methodTypes, $this->findUsedTypes($service, $type));
+                }
             }
             $operations[] = $operation;
             $types = array_merge($types, $methodTypes);

--- a/src/OutputManager.php
+++ b/src/OutputManager.php
@@ -132,7 +132,7 @@ class OutputManager
         // First we generate a string containing the known classes and the paths they map to. One line for each string.
         $autoloadedClasses = array();
         foreach ($classes as $class) {
-            $className = $this->config->get('namespaceName') . '\\' . $class->getIdentifier();
+            $className = $this->config->get('namespaceName') . '\\' . $class->getPrefix() . $class->getIdentifier();
             $className = ltrim($className, '\\');
             $autoloadedClasses[] = "'" . $className . "' => __DIR__ .'/" . $class->getIdentifier() . ".php'";
         }

--- a/src/Service.php
+++ b/src/Service.php
@@ -50,12 +50,18 @@ class Service implements ClassGenerator
      * @var Type[] An array of Types
      */
     private $types;
+    
+    /**
+     * @var string
+     */
+    private $classPrefix;
 
     /**
      * @param ConfigInterface $config Configuration
      * @param string $identifier The name of the service
      * @param array $types The types the service knows about
      * @param string $description The description of the service
+     * @param string $classPrefix Optional class prefix
      */
     public function __construct(ConfigInterface $config, $identifier, array $types, $description)
     {
@@ -65,7 +71,13 @@ class Service implements ClassGenerator
         $this->operations = array();
         $this->types = array();
         foreach ($types as $type) {
-            $this->types[$type->getIdentifier()] = $type;
+            if ($type !== null) {
+                $this->types[$type->getIdentifier()] = $type;
+            }
+        }
+        $this->classPrefix = "";
+        if ($this->config->get('classPrefix')) {
+          $this->classPrefix = $this->config->get('classPrefix');
         }
     }
 
@@ -149,7 +161,7 @@ class Service implements ClassGenerator
 
         // Create the class object
         $comment = new PhpDocComment($this->description);
-        $this->class = new PhpClass($name, false, $this->config->get('soapClientClass'), $comment);
+        $this->class = new PhpClass($name, false, $this->config->get('soapClientClass'), $comment, false, false, $this->classPrefix);
 
         // Create the constructor
         $comment = new PhpDocComment();

--- a/src/Type.php
+++ b/src/Type.php
@@ -46,6 +46,16 @@ abstract class Type implements ClassGenerator
      * @var string The datatype the simple type is of. This not used by complex types
      */
     protected $datatype;
+    
+    /**
+     * @var string Class prefix to append to all classes
+     */
+    protected $classPrefix;
+    
+    /**
+     * @var string A base class that each type class will extend at it's core
+     */
+    protected $baseClass;
 
     /**
      * The minimum construction
@@ -60,11 +70,20 @@ abstract class Type implements ClassGenerator
         $this->class = null;
         $this->datatype = $datatype;
         $this->identifier = $name;
+        $this->classPrefix = '';
+        $this->baseClass = '';
 
         $this->phpIdentifier = Validator::validateClass($name, $this->config->get('namespaceName'));
         $this->phpNamespacedIdentifier = $name;
         if ($this->config->get('namespaceName')) {
             $this->phpNamespacedIdentifier = '\\' . $this->config->get('namespaceName') . '\\' . $name;
+        }
+        
+        if ($this->config->get('classPrefix')) {
+          $this->classPrefix = $this->config->get('classPrefix');
+        }
+        if ($this->config->get('baseClass')) {
+          $this->baseClass = $this->config->get('baseClass');
         }
     }
 


### PR DESCRIPTION
- added `classPrefix` option for applications and frameworks not yet namespace ready
- added 'baseClass' option for all classes to extend
- fixed methods having a null return type