### PR TITLE
make default value for ArrayType an array

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,9 +16,9 @@
         }
     },
     "require": {
-        "php": "^7.2",
+        "php": "^7.2|^8.0",
         "ext-soap": "*",
-        "symfony/options-resolver": "^3.4.37",
+        "symfony/options-resolver": "^3.4.37|^4.4|^5.0",
         "symfony/polyfill-iconv": "^1.13.1"
     },
     "require-dev": {

--- a/src/ArrayType.php
+++ b/src/ArrayType.php
@@ -32,6 +32,11 @@ class ArrayType extends ComplexType
     protected $arrayOf;
 
     /**
+     * @var string
+     */
+    protected $memberDefaultValue = 'array()';
+
+    /**
      * Implements the loading of the class object
      *
      * @throws Exception if the class is already generated(not null)

--- a/src/ComplexType.php
+++ b/src/ComplexType.php
@@ -41,6 +41,11 @@ class ComplexType extends Type
     protected $abstract;
 
     /**
+     * @var string
+     */
+    protected $memberDefaultValue = 'null';
+
+    /**
      * Construct the object
      *
      * @param ConfigInterface $config The configuration
@@ -104,7 +109,7 @@ class ComplexType extends Type
 
             $comment = new PhpDocComment();
             $comment->setVar(PhpDocElementFactory::getVar($type, $name, ''));
-            $var = new PhpVariable('protected', $name, 'null', $comment);
+            $var = new PhpVariable('protected', $name, $this->memberDefaultValue, $comment);
             $this->class->addVariable($var);
 
             if (!$member->getNullable()) {


### PR DESCRIPTION
This changes the default value for ArrayTypes to array() instead of null.

Having null values here caused warning when using foreach on empty ArrayTypes.

> Warning: reset() expects parameter 1 to be array, null given

foreach internally triggers a reset before the loop.

Im not sure if we also should adjust the setter and the nullable behaviour?