### PR TITLE
Add missed validation for correct array and setter return types hinting

### DIFF
--- a/src/Type.php
+++ b/src/Type.php
@@ -62,9 +62,9 @@ abstract class Type implements ClassGenerator
         $this->identifier = $name;
 
         $this->phpIdentifier = Validator::validateClass($name, $this->config->get('namespaceName'));
-        $this->phpNamespacedIdentifier = $name;
+        $this->phpNamespacedIdentifier = $this->phpIdentifier;
         if ($this->config->get('namespaceName')) {
-            $this->phpNamespacedIdentifier = '\\' . $this->config->get('namespaceName') . '\\' . $name;
+            $this->phpNamespacedIdentifier = '\\' . $this->config->get('namespaceName') . '\\' . $this->phpIdentifier;
         }
     }
 

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -189,7 +189,7 @@ class Validator
     public static function validateType($typeName)
     {
         if (substr($typeName, -2) == "[]") {
-            return $typeName;
+            return self::validateNamingConvention(substr($typeName, 0, -2)) . "[]";
         }
 
         switch (strtolower($typeName)) {

--- a/tests/fixtures/wsdl/utf8/utf8.wsdl
+++ b/tests/fixtures/wsdl/utf8/utf8.wsdl
@@ -20,6 +20,12 @@
                              maxOccurs="1"/>
                 </sequence>
             </complexType>
+
+            <complexType name="ArrayOfMsgContraseña">
+                <sequence>
+                    <element maxOccurs="unbounded" minOccurs="0" name="Item" type="xsd:MsgContraseña"/>
+                </sequence>
+            </complexType>
         </schema>
     </wsdl:types>
 

--- a/tests/src/Functional/Utf8Test.php
+++ b/tests/src/Functional/Utf8Test.php
@@ -32,6 +32,25 @@ class Utf8Test extends FunctionalTestCase
 
         // Valid class name for UTF8 named type
         $this->assertGeneratedClassExists('MsgContrasena');
+
+        //Check arrayable UTF-8 complex type
+
+        // Valid file name for UTF8 named type
+        $this->assertGeneratedFileExists('ArrayOfMsgContrasena.php');
+
+        // Valid class name for UTF8 named type
+        $this->assertGeneratedClassExists('ArrayOfMsgContrasena');
+
+        $arrayableComplexTypeClass = new \ReflectionClass('ArrayOfMsgContrasena');
+
+        $arrayableComplexTypeSetterDocComment = $arrayableComplexTypeClass->getMethod("setItem")->getDocComment();
+
+        // Validate UTF8 names in DocComment types
+        $this->assertContains('@param MsgContrasena[]', $arrayableComplexTypeSetterDocComment, 
+                'Array setter method should contain param with valid UTF8 arrayable type, transliterated');
+
+        $this->assertContains('@return ArrayOfMsgContrasena', $arrayableComplexTypeSetterDocComment, 
+                'Array setter method should contain valid UTF8 return type, transliterated');
     }
 
 }

--- a/tests/src/Unit/ValidatorTest.php
+++ b/tests/src/Unit/ValidatorTest.php
@@ -72,6 +72,8 @@ class ValidatorTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('Foo[]', Validator::validateType('Foo[]'));
 
         $this->assertEquals('andCustom', Validator::validateType('and')); // and is reserved keyword
+
+        $this->assertEquals('validarContrasena[]', Validator::validateType('validarContraseña[]')); //UTF-8 array type
     }
 
 }


### PR DESCRIPTION
It fixes case, when non-ascii utf-8 types used in WSDL