### PR TITLE
Stop running travis-ci on php5.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6


### PR DESCRIPTION
Travis-ci no longer supports php5.3. Some details are [here](https://github.com/travis-ci/travis-ci/issues/8072) and [here](https://github.com/travis-ci/travis-ci/issues/2963). 