### PR TITLE
fix 'Parameter must be an array' bug

### DIFF
--- a/lib/PhpSource/PhpClass.php
+++ b/lib/PhpSource/PhpClass.php
@@ -109,6 +109,7 @@ class PhpClass extends PhpElement
         $this->identifier = $identifier;
         $this->access = '';
         $this->extends = $extends;
+        $this->implements = array();
         $this->constants = array();
         $this->variables = array();
         $this->functions = array();


### PR DESCRIPTION
Null can't be counted in php7.2