### PR TITLE
Allow services to have a suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,10 @@ The following formats are supported:
 
 The proxy information is used by is used when accessing the WSDL to generate the code and for subsequent requests to the SOAP service.
 
+#### `serviceSuffix`
+
+Append this suffix to service class name. This might help if some types have the same name as the service.
+
 ##### Example usage
 
 The following configuration will use a proxy to access the [Google DoubleClick Ad Exchange Buyer SOAP API](https://developers.google.com/ad-exchange/buyer-soap/):

--- a/src/Config.php
+++ b/src/Config.php
@@ -74,7 +74,8 @@ class Config implements ConfigInterface
             'constructorParamsDefaultToNull' => false,
             'soapClientClass'               => '\SoapClient',
             'soapClientOptions'             => array(),
-            'proxy'                         => false
+            'proxy'                         => false,
+            'serviceSuffix'                 => '',
         ));
 
         // A set of configuration options names and normalizer callables.

--- a/src/Service.php
+++ b/src/Service.php
@@ -60,7 +60,7 @@ class Service implements ClassGenerator
     public function __construct(ConfigInterface $config, $identifier, array $types, $description)
     {
         $this->config = $config;
-        $this->identifier = $identifier;
+        $this->identifier = $identifier . $config->get('serviceSuffix');
         $this->description = $description;
         $this->operations = array();
         $this->types = array();


### PR DESCRIPTION
In my case, the wsdl service have types that are the same name as the service.

This simple option allow to add a suffix at the end of the service identifier. It might also be easier to find the service amongst all the classes by using this option.