### PR TITLE
PHP 7.2 fix - count(): Parameter must be an array or an object that implements Countable

### DIFF
--- a/lib/PhpSource/PhpClass.php
+++ b/lib/PhpSource/PhpClass.php
@@ -48,7 +48,7 @@ class PhpClass extends PhpElement
      * @var string[]
      * @access private
      */
-    private $implements;
+    private $implements = [];
 
     /**
      *


### PR DESCRIPTION
count(): Parameter must be an array or an object that implements Countable.

Have tested with PHP 7.2 working as expected with this fix.