### PR TITLE
Fix PHP 5.3 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6
@@ -9,9 +8,18 @@ php:
   - 7.1
 
 env:
-  matrix:
-    - PREFER_LOWEST="--prefer-lowest"
-    - PREFER_LOWEST=""
+  - PREFER_LOWEST="--prefer-lowest"
+  - PREFER_LOWEST=""
+
+matrix:
+  include:
+    # PHP 5.3 builds have to be included manually as they require precise
+    - php: 5.3
+      dist: precise
+      env: PREFER_LOWEST="--prefer-lowest"
+    - php: 5.3
+      dist: precise
+      env: PREFER_LOWEST=""
 
 sudo: false
 


### PR DESCRIPTION
See https://docs.travis-ci.com/user/reference/trusty#PHP-images

We can only specify which distribution to run tests on in the matrix
definition. Move all versions there for the sake of consistency.

Withtout this the 5.3 build will fail as it is not available on
Ubuntu 14.04.5 LTS (Trusty Tahr)