### PR TITLE
Initialize the `implements` Property in `PhpClass`

### DIFF
--- a/lib/PhpSource/PhpClass.php
+++ b/lib/PhpSource/PhpClass.php
@@ -112,6 +112,7 @@ class PhpClass extends PhpElement
         $this->constants = array();
         $this->variables = array();
         $this->functions = array();
+        $this->implements = array();
         $this->indentionStr = '    '; // Use 4 spaces as indention, as requested by PSR-2
         $this->abstract = $abstract;
     }


### PR DESCRIPTION
So there are no `count()` warnings produced during tests.

Closes #330 