### PR TITLE
Fix: Clean up Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,31 +1,42 @@
 language: php
 
-php:
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
-  - 7.1
-
-env:
-  - PREFER_LOWEST="--prefer-lowest"
-  - PREFER_LOWEST=""
+sudo: false
 
 matrix:
   include:
-    # PHP 5.3 builds have to be included manually as they require precise
     - php: 5.3
       dist: precise
-      env: PREFER_LOWEST="--prefer-lowest"
+      env: WITH_LOWEST=true
     - php: 5.3
       dist: precise
-      env: PREFER_LOWEST=""
+      env: WITH_HIGHEST=true
+    - php: 5.4
+      env: WITH_LOWEST=true
+    - php: 5.4
+      env: WITH_HIGHEST=true
+    - php: 5.5
+      env: WITH_LOWEST=true
+    - php: 5.5
+      env: WITH_HIGHEST=true
+    - php: 5.6
+      env: WITH_LOWEST=true
+    - php: 5.6
+      env: WITH_HIGHEST=true
+    - php: 7.0
+      env: WITH_LOWEST=true
+    - php: 7.0
+      env: WITH_HIGHEST=true
+    - php: 7.1
+      env: WITH_LOWEST=true
+    - php: 7.1
+      env: WITH_HIGHEST=true
 
-sudo: false
+install:
+  - if [[ "$WITH_LOWEST" == "true" ]]; then composer update --prefer-lowest; fi
+  - if [[ "$WITH_HIGHEST" == "true" ]]; then composer update; fi
 
 before_script:
-  - composer update --no-interaction $PREFER_LOWEST
+  - mkdir -p build/logs
 
 script:
-  - mkdir -p build/logs
   - php vendor/bin/phpunit -c phpunit.xml.dist


### PR DESCRIPTION
This PR

* [x] cleans up the Travis CI configuration

💁‍♂️ While matrix expansion is fine, it doesn't provide very nice results in terms of order of the jobs.

### Before

See https://travis-ci.org/wsdl2phpgenerator/wsdl2phpgenerator/builds/396706850:

![screen shot 2018-07-31 at 11 06 27](https://user-images.githubusercontent.com/605483/43449971-025405d2-94b2-11e8-96e4-f382df7e9d8f.png)

### After

See https://travis-ci.org/wsdl2phpgenerator/wsdl2phpgenerator/builds/410228878:

![screen shot 2018-07-31 at 11 06 13](https://user-images.githubusercontent.com/605483/43449953-f9b4d208-94b1-11e8-8650-27a41bcff108.png)

💡 For reference, also see https://docs.travis-ci.com/user/customizing-the-build/#the-build-lifecycle.