### PR TITLE
Enhancement: Cache dependencies between builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ php:
   - 7.0
   - 7.1
 
+cache:
+  directories:
+    - $HOME/.composer/cache
+
 env:
   - PREFER_LOWEST="--prefer-lowest"
   - PREFER_LOWEST=""


### PR DESCRIPTION
This PR

* [x] caches dependencies as installed with `composer` between Travis CI builds

💁‍♂️ For reference, see https://docs.travis-ci.com/user/caching/#arbitrary-directories.