### PR TITLE
WIP New Options excludeMethodParamTypeHints and constructorParamsIncludeNullable

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,10 @@ If enabled this sets the default value of all parameters in all constructors to 
 
 If enabled, type hints will not be generated for method parameters.
 
+#### `constructorParamsIncludeNullable`
+
+If enabled, constructors will include parameters for nullable field values.
+
 #### `proxy`
 
 Specify a proxy to use when accessing the WSDL and other external ressources. This option should be used instead of [the proxy options support by the PHP `SoapClient`] (http://php.net/manual/en/soapclient.soapclient.php) as wsdl2phpgenerator uses more than the SOAP client to extract information.

--- a/README.md
+++ b/README.md
@@ -160,6 +160,10 @@ If enabled this makes all types with the same identify use the same class and on
 
 If enabled this sets the default value of all parameters in all constructors to `null`. If this is used then properties must be set using accessors.
 
+#### `excludeMethodParamTypeHints`
+
+If enabled, type hints will not be generated for method parameters.
+
 #### `proxy`
 
 Specify a proxy to use when accessing the WSDL and other external ressources. This option should be used instead of [the proxy options support by the PHP `SoapClient`] (http://php.net/manual/en/soapclient.soapclient.php) as wsdl2phpgenerator uses more than the SOAP client to extract information.
@@ -193,7 +197,7 @@ The base class to use for generated services. This should be a subclass of the [
 Examples of third party SOAP client implementations which can be used:
 
 * [BeSimpleSoapClient](https://github.com/BeSimple/BeSimpleSoapClient)
-* [ZendFramework2 SOAP Component](https://github.com/zendframework/Component_ZendSoap) 
+* [ZendFramework2 SOAP Component](https://github.com/zendframework/Component_ZendSoap)
 * [soap-plus](https://github.com/dcarbone/soap-plus)
 * [SoapClientEx](https://gist.github.com/RobThree/4117914)
 

--- a/src/ComplexType.php
+++ b/src/ComplexType.php
@@ -87,10 +87,10 @@ class ComplexType extends Type
             foreach ($parentMembers as $member) {
                 $type = Validator::validateType($member->getType());
                 $name = Validator::validateAttribute($member->getName());
-
-                $constructorComment->addParam(PhpDocElementFactory::getParam($type, $name, ''));
-                $constructorParameters[$name] = Validator::validateTypeHint($type);
-
+				if (!$member->getNullable() || $this->config->get('constructorParamsIncludeNullable')) {
+                   $constructorComment->addParam(PhpDocElementFactory::getParam($type, $name, ''));
+                   $constructorParameters[$name] = Validator::validateTypeHint($type);
+				}
             }
             $constructorSource .= '  parent::__construct(' . $this->buildParametersString($constructorParameters, false) . ');' . PHP_EOL;
         }
@@ -106,7 +106,7 @@ class ComplexType extends Type
             $var = new PhpVariable('protected', $name, 'null', $comment);
             $this->class->addVariable($var);
 
-            if (!$member->getNullable()) {
+            if (!$member->getNullable() || $this->config->get('constructorParamsIncludeNullable')) {
                 if ($type == '\DateTime') {
                     if ($this->config->get('constructorParamsDefaultToNull')) {
                         $constructorSource .= '  $this->' . $name . ' = $' . $name . ' ? $' . $name . '->format(\DateTime::ATOM) : null;' . PHP_EOL;

--- a/src/ComplexType.php
+++ b/src/ComplexType.php
@@ -88,10 +88,9 @@ class ComplexType extends Type
                 $type = Validator::validateType($member->getType());
                 $name = Validator::validateAttribute($member->getName());
 
-                if (!$member->getNullable()) {
-                    $constructorComment->addParam(PhpDocElementFactory::getParam($type, $name, ''));
-                    $constructorParameters[$name] = Validator::validateTypeHint($type);
-                }
+                $constructorComment->addParam(PhpDocElementFactory::getParam($type, $name, ''));
+                $constructorParameters[$name] = Validator::validateTypeHint($type);
+
             }
             $constructorSource .= '  parent::__construct(' . $this->buildParametersString($constructorParameters, false) . ');' . PHP_EOL;
         }
@@ -161,7 +160,7 @@ class ComplexType extends Type
                 'set' . ucfirst($name),
                 $this->buildParametersString(
                     array($name => $typeHint),
-                    true,
+                    !$this->config->get('excludeMethodParamTypeHints'),
                     // If the type of a member is nullable we should allow passing null to the setter. If the type
                     // of the member is a class and not a primitive this is only possible if setter parameter has
                     // a default null value. We can detect whether the type is a class by checking the type hint.
@@ -178,7 +177,7 @@ class ComplexType extends Type
             '__construct',
             $this->buildParametersString(
                 $constructorParameters,
-                true,
+                !$this->config->get('excludeMethodParamTypeHints'),
                 $this->config->get('constructorParamsDefaultToNull')
             ),
             $constructorSource,

--- a/src/Config.php
+++ b/src/Config.php
@@ -72,6 +72,7 @@ class Config implements ConfigInterface
             'operationNames'                 => '',
             'sharedTypes'                    => false,
             'constructorParamsDefaultToNull' => false,
+            'excludeMethodParamTypeHints'    => false,
             'soapClientClass'               => '\SoapClient',
             'soapClientOptions'             => array(),
             'proxy'                         => false

--- a/src/Config.php
+++ b/src/Config.php
@@ -73,6 +73,7 @@ class Config implements ConfigInterface
             'sharedTypes'                    => false,
             'constructorParamsDefaultToNull' => false,
             'excludeMethodParamTypeHints'    => false,
+	   	 	'constructorParamsIncludeNullable'	=> false,
             'soapClientClass'               => '\SoapClient',
             'soapClientOptions'             => array(),
             'proxy'                         => false


### PR DESCRIPTION
I am working with WSDLs from major shipping carriers, using PHP 5.6, and these options were useful to me:
excludeMethodParamTypeHints - these aren't supported in PHP 5; enabling this option turns off type hinting.
constructorParamsIncludeNullable - most (probably all) of the fields I was encountering (on two different carriers now) are nullable, but I still want to be able to specify values in the constructor.  This bypasses the getNullable check and simply adds all fields to the constructor.

I added comments in the README that explain what they do.  Test cases pass (though I haven't had time to write anything covering these two flags).  The default behavior is unchanged.