### PR TITLE
BM2-1165 - fixed different issues in class generator; added new featu…

### DIFF
--- a/lib/PhpSource/PhpClass.php
+++ b/lib/PhpSource/PhpClass.php
@@ -17,10 +17,24 @@ class PhpClass extends PhpElement
 {
     /**
      *
+     * @var string namespace rewrite (optional)
+     * @access private
+     */
+    private $classNamespace = '';
+
+    /**
+     *
      * @var array An array of strings, contains all the filenames to include for the class
      * @access private
      */
     private $dependencies;
+
+    /**
+     *
+     * @var array An array of strings, contains all the classes to import for the class
+     * @access private
+     */
+    private $namespaces;
 
     /**
      *
@@ -103,6 +117,7 @@ class PhpClass extends PhpElement
     public function __construct($identifier, $classExists = false, $extends = '', PhpDocComment $comment = null, $final = false, $abstract = false)
     {
         $this->dependencies = array();
+        $this->namespaces = array();
         $this->classExists = $classExists;
         $this->comment = $comment;
         $this->final = $final;
@@ -135,6 +150,13 @@ class PhpClass extends PhpElement
             $ret .= PHP_EOL;
         }
 
+        if (count($this->namespaces) > 0) {
+            foreach ($this->namespaces as $namespace) {
+                $ret .= 'use ' . $namespace . ';' . PHP_EOL;
+            }
+            $ret .= PHP_EOL;
+        }
+
         if ($this->comment !== null) {
             $ret .= $this->comment->getSource();
         }
@@ -157,17 +179,24 @@ class PhpClass extends PhpElement
             $ret .= ' implements ' . implode(', ', $this->implements);
         }
 
-        $ret .= PHP_EOL . '{' . PHP_EOL;
+        $ret .= PHP_EOL . '{';
 
         if (isset($this->default)) {
+            $ret .= PHP_EOL;
             $ret .= $this->getIndentionStr() . 'const __default = ' . $this->default . ';' . PHP_EOL;
         }
 
         if (count($this->constants) > 0) {
-            foreach ($this->constants as $name => $value) {
-                $ret .= $this->getIndentionStr() . 'const ' . $name . ' = \'' . $value . '\';' . PHP_EOL;
-            }
             $ret .= PHP_EOL;
+            foreach ($this->constants as $name => $value) {
+                $ret .= $this->getIndentionStr() . 'const ' . $name . ' = ';
+                if (is_array($value)) {
+                    $options = explode(PHP_EOL, var_export($value, true));
+                    $ret .= implode(PHP_EOL . $this->getIndentionStr(), $options) . ';' . PHP_EOL;
+                } else {
+                    $ret .= '\'' . $value . '\';' . PHP_EOL;
+                }
+            }
         }
 
         if (count($this->variables) > 0) {
@@ -184,13 +213,34 @@ class PhpClass extends PhpElement
             }
         }
 
-        $ret .= PHP_EOL . '}' . PHP_EOL;
+        $ret .= '}' . PHP_EOL;
 
         if ($this->classExists) {
             $ret .= PHP_EOL . '}' . PHP_EOL;
         }
 
         return $ret;
+    }
+
+    /**
+     * Sets class namespace rewrite
+     *
+     * @param string $namespace
+     * @return void
+     */
+    public function setClassNamespace($namespace)
+    {
+        $this->classNamespace = $namespace;
+    }
+
+    /**
+     * Retrieve class namespace rewrite
+     *
+     * @return string
+     */
+    public function getClassNamespace()
+    {
+        return $this->classNamespace;
     }
 
     /**
@@ -203,6 +253,18 @@ class PhpClass extends PhpElement
     {
         if (in_array($filename, $this->dependencies) == false) {
             $this->dependencies[] = $filename;
+        }
+    }
+
+    /**
+     * Adds a class name to be imported for the class to use
+     *
+     * @param string $className
+     */
+    public function addNamespace($className)
+    {
+        if (in_array($className, $this->namespaces) == false) {
+            $this->namespaces[] = $className;
         }
     }
 
@@ -229,12 +291,12 @@ class PhpClass extends PhpElement
      * Adds a constant to the class. If no name is supplied and the value is a string the value is used as name otherwise exception is raised
      *
      * @param mixed $value
-     * @param string $name
+     * @param string|array $name
      * @throws Exception
      */
     public function addConstant($value, $name = '')
     {
-        if (strlen($value) == 0) {
+        if ((is_string($value) && strlen($value) == 0) || is_array($value) && !$value) {
             throw new Exception('No value supplied');
         }
 

--- a/src/ArrayType.php
+++ b/src/ArrayType.php
@@ -52,6 +52,9 @@ class ArrayType extends ComplexType
         $this->class->addImplementation('\\ArrayAccess');
         $description = 'ArrayAccess implementation';
 
+        $name = Validator::validateAttribute($this->field->getName());
+        $indentionStr = $this->config->get('indentionStr');
+
         $offsetExistsDock = new PhpDocComment();
         $offsetExistsDock->setDescription($description);
         $offsetExistsDock->addParam(PhpDocElementFactory::getParam('mixed', 'offset', 'An offset to check for'));
@@ -66,7 +69,7 @@ class ArrayType extends ComplexType
                 false,
                 false
             ),
-            '  return isset($this->' . $this->field->getName() . '[$offset]);',
+            $indentionStr . 'return isset($this->' . $name . '[$offset]);',
             $offsetExistsDock
         );
         $this->class->addFunction($offsetExists);
@@ -85,7 +88,7 @@ class ArrayType extends ComplexType
                 false,
                 false
             ),
-            '  return $this->' . $this->field->getName() . '[$offset];',
+            $indentionStr . 'return $this->' . $name . '[$offset];',
             $offsetGetDock
         );
         $this->class->addFunction($offsetGet);
@@ -106,11 +109,11 @@ class ArrayType extends ComplexType
                 false,
                 false
             ),
-            '  if (!isset($offset)) {' . PHP_EOL .
-            '    $this->' . $this->field->getName() . '[] = $value;' . PHP_EOL .
-            '  } else {' . PHP_EOL .
-            '    $this->' . $this->field->getName() . '[$offset] = $value;' . PHP_EOL .
-            '  }',
+            $indentionStr . 'if (!isset($offset)) {' . PHP_EOL .
+            str_repeat($indentionStr, 2) . '$this->' . $name . '[] = $value;' . PHP_EOL .
+            $indentionStr . '} else {' . PHP_EOL .
+            str_repeat($indentionStr, 2) . '$this->' . $name . '[$offset] = $value;' . PHP_EOL .
+            $indentionStr . '}',
             $offsetSetDock
         );
         $this->class->addFunction($offsetSet);
@@ -129,7 +132,7 @@ class ArrayType extends ComplexType
                 false,
                 false
             ),
-            '  unset($this->' . $this->field->getName() . '[$offset]);',
+            $indentionStr . 'unset($this->' . $name . '[$offset]);',
             $offsetUnsetDock
         );
         $this->class->addFunction($offsetUnset);
@@ -139,6 +142,9 @@ class ArrayType extends ComplexType
     {
         $this->class->addImplementation('\\Iterator');
         $description = 'Iterator implementation';
+
+        $name = Validator::validateAttribute($this->field->getName());
+        $indentionStr = $this->config->get('indentionStr');
 
         $currentDock = new PhpDocComment();
         $currentDock->setDescription($description);
@@ -151,7 +157,7 @@ class ArrayType extends ComplexType
                 false,
                 false
             ),
-            '  return current($this->' . $this->field->getName() . ');',
+            $indentionStr . 'return current($this->' . $name . ');',
             $currentDock
         );
         $this->class->addFunction($current);
@@ -167,7 +173,7 @@ class ArrayType extends ComplexType
                 false,
                 false
             ),
-            '  next($this->' . $this->field->getName() . ');',
+            $indentionStr . 'next($this->' . $name . ');',
             $nextDock
         );
         $this->class->addFunction($next);
@@ -183,7 +189,7 @@ class ArrayType extends ComplexType
                 false,
                 false
             ),
-            '  return key($this->' . $this->field->getName() . ');',
+            $indentionStr . 'return key($this->' . $name . ');',
             $keyDock
         );
         $this->class->addFunction($key);
@@ -199,7 +205,7 @@ class ArrayType extends ComplexType
                 false,
                 false
             ),
-            '  return $this->key() !== null;',
+            $indentionStr . 'return $this->key() !== null;',
             $validDock
         );
         $this->class->addFunction($valid);
@@ -215,7 +221,7 @@ class ArrayType extends ComplexType
                 false,
                 false
             ),
-            '  reset($this->' . $this->field->getName() . ');',
+            $indentionStr . 'reset($this->' . $name . ');',
             $rewindDock
         );
         $this->class->addFunction($rewind);
@@ -225,6 +231,9 @@ class ArrayType extends ComplexType
     {
         $this->class->addImplementation('\\Countable');
         $description = 'Countable implementation';
+
+        $name = Validator::validateAttribute($this->field->getName());
+        $indentionStr = $this->config->get('indentionStr');
 
         $countDock = new PhpDocComment();
         $countDock->setDescription($description);
@@ -237,7 +246,7 @@ class ArrayType extends ComplexType
                 false,
                 false
             ),
-            '  return count($this->' . $this->field->getName() . ');',
+            $indentionStr . 'return count($this->' . $name . ');',
             $countDock
         );
         $this->class->addFunction($count);
@@ -247,7 +256,7 @@ class ArrayType extends ComplexType
     {
         $members = array_values($this->members);
         $this->field = $members[0];
-        $this->arrayOf = substr($this->field->getType(), 0, -2);
+        $this->arrayOf = Validator::validateType(substr($this->field->getType(), 0, -2));
 
         $this->implementArrayAccess();
         $this->implementIterator();

--- a/src/ComplexType.php
+++ b/src/ComplexType.php
@@ -66,6 +66,8 @@ class ComplexType extends Type
         }
 
         $classBaseType = $this->getBaseTypeClass();
+        $indentionStr = $this->config->get('indentionStr');
+        $variableAccess = $this->config->get('varAccess');
 
         $this->class = new PhpClass(
             $this->phpIdentifier,
@@ -78,7 +80,9 @@ class ComplexType extends Type
 
         $constructorComment = new PhpDocComment();
         $constructorSource = '';
+        $constructorParentCall = '';
         $constructorParameters = array();
+        $constructorParametersParent = array();
         $accessors = array();
 
         // Add base type members to constructor parameter list first and call base class constructor
@@ -93,7 +97,9 @@ class ComplexType extends Type
                     $constructorParameters[$name] = Validator::validateTypeHint($type);
                 }
             }
-            $constructorSource .= '  parent::__construct(' . $this->buildParametersString($constructorParameters, false) . ');' . PHP_EOL;
+            $constructorParametersParent = $constructorParameters;
+            $constructorParentCall = $indentionStr . 'parent::__construct(' . $this->buildParametersString($constructorParameters, false) . ');' . PHP_EOL;
+            $constructorSource .= $constructorParentCall;
         }
 
         // Add member variables
@@ -104,18 +110,18 @@ class ComplexType extends Type
 
             $comment = new PhpDocComment();
             $comment->setVar(PhpDocElementFactory::getVar($type, $name, ''));
-            $var = new PhpVariable('protected', $name, 'null', $comment);
+            $var = new PhpVariable($variableAccess, $name, 'null', $comment);
             $this->class->addVariable($var);
 
             if (!$member->getNullable()) {
                 if ($type == '\DateTime') {
                     if ($this->config->get('constructorParamsDefaultToNull')) {
-                        $constructorSource .= '  $this->' . $name . ' = $' . $name . ' ? $' . $name . '->format(\DateTime::ATOM) : null;' . PHP_EOL;
+                        $constructorSource .= $indentionStr . '$this->' . $name . ' = $' . $name . ' ? $' . $name . '->format(\DateTime::ATOM) : null;' . PHP_EOL;
                     } else {
-                        $constructorSource .= '  $this->' . $name . ' = $' . $name . '->format(\DateTime::ATOM);' . PHP_EOL;
+                        $constructorSource .= $indentionStr . '$this->' . $name . ' = $' . $name . '->format(\DateTime::ATOM);' . PHP_EOL;
                     }
                 } else {
-                    $constructorSource .= '  $this->' . $name . ' = $' . $name . ';' . PHP_EOL;
+                    $constructorSource .= $indentionStr . '$this->' . $name . ' = $' . $name . ';' . PHP_EOL;
                 }
                 $constructorComment->addParam(PhpDocElementFactory::getParam($type, $name, ''));
                 $constructorParameters[$name] = $typeHint;
@@ -124,17 +130,17 @@ class ComplexType extends Type
             $getterComment = new PhpDocComment();
             $getterComment->setReturn(PhpDocElementFactory::getReturn($type, ''));
             if ($type == '\DateTime') {
-                $getterCode = '  if ($this->' . $name . ' == null) {' . PHP_EOL
-                    . '    return null;' . PHP_EOL
-                    . '  } else {' . PHP_EOL
-                    . '    try {' . PHP_EOL
-                    . '      return new \DateTime($this->' . $name . ');' . PHP_EOL
-                    . '    } catch (\Exception $e) {' . PHP_EOL
-                    . '      return false;' . PHP_EOL
-                    . '    }' . PHP_EOL
-                    . '  }' . PHP_EOL;
+                $getterCode = $indentionStr . 'if ($this->' . $name . ' == null) {' . PHP_EOL
+                    . str_repeat($indentionStr, 2) . 'return null;' . PHP_EOL
+                    . $indentionStr . '} else {' . PHP_EOL
+                    . str_repeat($indentionStr, 2) . 'try {' . PHP_EOL
+                    . str_repeat($indentionStr, 3) . 'return new \DateTime($this->' . $name . ');' . PHP_EOL
+                    . str_repeat($indentionStr, 2) . '} catch (\Exception $e) {' . PHP_EOL
+                    . str_repeat($indentionStr, 3) . 'return false;' . PHP_EOL
+                    . str_repeat($indentionStr, 2) . '}' . PHP_EOL
+                    . $indentionStr . '}' . PHP_EOL;
             } else {
-                $getterCode = '  return $this->' . $name . ';' . PHP_EOL;
+                $getterCode = $indentionStr . 'return $this->' . $name . ';' . PHP_EOL;
             }
             $getter = new PhpFunction('public', 'get' . ucfirst($name), '', $getterCode, $getterComment);
             $accessors[] = $getter;
@@ -144,18 +150,18 @@ class ComplexType extends Type
             $setterComment->setReturn(PhpDocElementFactory::getReturn($this->phpNamespacedIdentifier, ''));
             if ($type == '\DateTime') {
                 if ($member->getNullable()) {
-                    $setterCode = '  if ($' . $name . ' == null) {' . PHP_EOL
-                        . '   $this->' . $name . ' = null;' . PHP_EOL
-                        . '  } else {' . PHP_EOL
-                        . '    $this->' . $name . ' = $' . $name . '->format(\DateTime::ATOM);' . PHP_EOL
-                        . '  }' . PHP_EOL;
+                    $setterCode = $indentionStr . 'if ($' . $name . ' == null) {' . PHP_EOL
+                        . str_repeat($indentionStr, 2) . '$this->' . $name . ' = null;' . PHP_EOL
+                        . $indentionStr . '} else {' . PHP_EOL
+                        . str_repeat($indentionStr, 2) . '$this->' . $name . ' = $' . $name . '->format(\DateTime::ATOM);' . PHP_EOL
+                        . $indentionStr . '}' . PHP_EOL;
                 } else {
-                    $setterCode = '  $this->' . $name . ' = $' . $name . '->format(\DateTime::ATOM);' . PHP_EOL;
+                    $setterCode = $indentionStr . '$this->' . $name . ' = $' . $name . '->format(\DateTime::ATOM);' . PHP_EOL;
                 }
             } else {
-                $setterCode = '  $this->' . $name . ' = $' . $name . ';' . PHP_EOL;
+                $setterCode = $indentionStr . '$this->' . $name . ' = $' . $name . ';' . PHP_EOL;
             }
-            $setterCode .= '  return $this;' . PHP_EOL;
+            $setterCode .= $indentionStr . 'return $this;' . PHP_EOL;
             $setter = new PhpFunction(
                 'public',
                 'set' . ucfirst($name),
@@ -173,18 +179,22 @@ class ComplexType extends Type
             $accessors[] = $setter;
         }
 
-        $constructor = new PhpFunction(
-            'public',
-            '__construct',
-            $this->buildParametersString(
-                $constructorParameters,
-                true,
-                $this->config->get('constructorParamsDefaultToNull')
-            ),
-            $constructorSource,
-            $constructorComment
-        );
-        $this->class->addFunction($constructor);
+        if (($constructorParameters && $constructorParameters !== $constructorParametersParent)
+            || ($constructorSource && $constructorSource !== $constructorParentCall)
+        ) {
+            $constructor = new PhpFunction(
+                'public',
+                '__construct',
+                $this->buildParametersString(
+                    $constructorParameters,
+                    true,
+                    $this->config->get('constructorParamsDefaultToNull')
+                ),
+                $constructorSource,
+                $constructorComment
+            );
+            $this->class->addFunction($constructor);
+        }
 
         foreach ($accessors as $accessor) {
             $this->class->addFunction($accessor);

--- a/src/Config.php
+++ b/src/Config.php
@@ -74,7 +74,13 @@ class Config implements ConfigInterface
             'constructorParamsDefaultToNull' => false,
             'soapClientClass'               => '\SoapClient',
             'soapClientOptions'             => array(),
-            'proxy'                         => false
+            'proxy'                         => false,
+            'varAccess'                     => 'protected',
+            'generateService'               => true,
+            'generateAutoloader'            => true,
+            'indentionStr'                  => '    ',// Use 4 spaces as indention, as requested by PSR-2
+            'disclaimer'                    => '',
+            'pluginClassList'               => array(),
         ));
 
         // A set of configuration options names and normalizer callables.

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -9,6 +9,7 @@ use \Exception;
 use Psr\Log\LoggerInterface;
 use Wsdl2PhpGenerator\Filter\FilterFactory;
 use Wsdl2PhpGenerator\Xml\WsdlDocument;
+use Wsdl2PhpGenerator\PluginInterface;
 
 /**
  * Class that contains functionality for generating classes from a wsdl file
@@ -213,6 +214,15 @@ class Generator implements GeneratorInterface
         }
 
         $output = new OutputManager($this->config);
+
+        foreach ((array) $this->config->get('pluginClassList') as $pluginClassName) {
+            if (!is_subclass_of($pluginClassName, '\Wsdl2PhpGenerator\PluginInterface')) {
+                continue;
+            }
+            /** @var PluginInterface $pluginClass */
+            $pluginClass = new $pluginClassName();
+            $pluginClass->process($this->config, $filteredService, $filteredTypes);
+        }
 
         // Generate all type classes
         $types = array();

--- a/src/OutputManager.php
+++ b/src/OutputManager.php
@@ -47,14 +47,21 @@ class OutputManager
     public function save(PhpClass $service, array $types)
     {
         $this->setOutputDirectory();
+        $classes = array();
 
-        $this->saveClassToFile($service);
-        foreach ($types as $type) {
-            $this->saveClassToFile($type);
+        if ($this->config->get('generateService')) {
+            $this->saveClassToFile($service);
+            $classes[] = $service;
         }
 
-        $classes = array_merge(array($service), $types);
-        $this->saveAutoloader($service->getIdentifier(), $classes);
+        foreach ($types as $type) {
+            $this->saveClassToFile($type);
+            $classes[] = $type;
+        }
+
+        if ($this->config->get('generateAutoloader')) {
+            $this->saveAutoloader($service->getIdentifier(), $classes);
+        }
     }
 
     /**
@@ -87,6 +94,7 @@ class OutputManager
     {
         if ($this->isValidClass($class)) {
             $file = new PhpFile($class->getIdentifier());
+            $file->addDisclaimer($this->config->get('disclaimer'));
 
             $namespace = $this->config->get('namespaceName');
             if (!empty($namespace)) {

--- a/src/PluginInterface.php
+++ b/src/PluginInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Wsdl2PhpGenerator;
+
+/**
+ * The plugin interface, which can be used to alter
+ * service or types objects before save.
+ * It can be also used to generate additional custom
+ * classes
+ *
+ * @package Wsdl2PhpGenerator
+ */
+
+use Wsdl2PhpGenerator\ConfigInterface;
+use Wsdl2PhpGenerator\Service;
+
+interface PluginInterface
+{
+    /**
+     * Processes service class and the list of corresponding types.
+     * Optionally generates additional custom classes.
+     *
+     * @param  ConfigInterface $config
+     * @param  Service $filteredService
+     * @param  array $filteredTypes
+     * @return void
+     */
+    public function process(ConfigInterface $config, Service $filteredService, array &$filteredTypes);
+}

--- a/src/Type.php
+++ b/src/Type.php
@@ -56,15 +56,16 @@ abstract class Type implements ClassGenerator
      */
     public function __construct(ConfigInterface $config, $name, $datatype)
     {
+        $name = Validator::validateAttribute($name);
         $this->config = $config;
         $this->class = null;
         $this->datatype = $datatype;
         $this->identifier = $name;
 
         $this->phpIdentifier = Validator::validateClass($name, $this->config->get('namespaceName'));
-        $this->phpNamespacedIdentifier = $this->phpIdentifier;
+        $this->phpNamespacedIdentifier = $name;
         if ($this->config->get('namespaceName')) {
-            $this->phpNamespacedIdentifier = '\\' . $this->config->get('namespaceName') . '\\' . $this->phpIdentifier;
+            $this->phpNamespacedIdentifier = '\\' . $this->config->get('namespaceName') . '\\' . $name;
         }
     }
 

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -188,8 +188,9 @@ class Validator
      */
     public static function validateType($typeName)
     {
-        if (substr($typeName, -2) == "[]") {
-            return self::validateNamingConvention(substr($typeName, 0, -2)) . "[]";
+        $arraySuffix = "[]";
+        if (substr($typeName, -2) == $arraySuffix) {
+            return  self::validateNamingConvention(substr($typeName, 0, -2)) . $arraySuffix;;
         }
 
         switch (strtolower($typeName)) {


### PR DESCRIPTION
- Removed empty constructors from generated code
-Removed redundant constructors, which contained only call of parent constructor.
- Fixed different issues around class names, method names and annotations for case when '.' is present in the name of type or operation in XML
- Improved formatting of the output, which now is closer to PSR-2
- Added possibility to generate PHP code with array constants.
- Added possibility to use custom namespace for the class
- Added possibility to generate PHP class with imported namespaces
- Added possibility to insert disclaimers to PHP classes
- Added possibility to use custom plugins to modify generated classes.
- Added possibility to prevent of generation of autoloader class
- Added possibility to prevent of generation of service class
- Added few config options with corresponding default values