### PR TITLE
Async SOAP class generation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,9 @@ $generator->generate(
     ))
 ));
 ````
+#### `fullTypeHints`
+
+Boolean, defaults to `false`. Setting to `true` adds full PHP 7.4 type hints, both for parameters and return types.
 
 #### `async`
 
@@ -312,7 +315,7 @@ $generator->generate(
 ```php
 $service = new MySoapService();
 
-$service->operationA(new operationA(), function (operationAResponse $success, $failure) {
+$service->operationAAsync(new operationA(), function (operationAResponse $success, $failure) {
     if ( $success ) {
         echo "Operation A is a success!";
         var_dump($success);
@@ -322,7 +325,7 @@ $service->operationA(new operationA(), function (operationAResponse $success, $f
     }
 });
 
-$service->operationB(new operationB(), function (operationBResponse $success, $failure) {
+$service->operationBAsync(new operationB(), function (operationBResponse $success, $failure) {
     if ( $success ) {
         echo "Operation B is a success!";
         var_dump($success);
@@ -338,6 +341,13 @@ $service->operationB(new operationB(), function (operationBResponse $success, $f
 // When using a custom implementation, there may be a different method.
 $service->__waitForAll();
 ```
+
+#### `promises`
+
+Boolean. Defaults to `false`. If set to `true`, and `async` is also `true`, then the generated class will use GuzzleHtp
+promises instead. Async methods will **NOT** take an extra `$callback` parameter, and instead will return a `Promise`.
+The `__soapCallAsync()` method in the base class must also be changed correspondingly and a reference implementation
+for this is not provided.
 
 ## Versioning
 

--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,11 @@
         }
     },
     "require": {
-        "php": ">=5.3.0",
+        "php": ">=5.4",
         "ext-soap": "*",
         "symfony/options-resolver": "~2.6|~3.0",
-        "symfony/polyfill-iconv": "^1.2"
+        "symfony/polyfill-iconv": "^1.2",
+        "ext-intl": "*"
     },
     "require-dev": {
         "kasperg/phing-github": "0.2.*",

--- a/lib/PhpSource/PhpClass.php
+++ b/lib/PhpSource/PhpClass.php
@@ -153,7 +153,7 @@ class PhpClass extends PhpElement
             $ret .= ' extends ' . $this->extends;
         }
 
-        if (count($this->implements) > 0) {
+        if ( $this->implements ) {
             $ret .= ' implements ' . implode(', ', $this->implements);
         }
 

--- a/lib/PhpSource/PhpFunction.php
+++ b/lib/PhpSource/PhpFunction.php
@@ -53,7 +53,14 @@ class PhpFunction extends PhpElement
         $this->params = $params;
         $this->source = $source;
         $this->comment = $comment;
-        $this->returnType = $returnType;
+
+        if ( $returnType ) {
+            if (substr($returnType, -2) == '[]') {
+                $this->returnType = $returnType[0] == '?' ? '?array' : 'array';
+            }
+        } else {
+            $this->returnType = null;
+        }
     }
 
     /**

--- a/lib/PhpSource/PhpFunction.php
+++ b/lib/PhpSource/PhpFunction.php
@@ -34,21 +34,26 @@ class PhpFunction extends PhpElement
      */
     private $comment;
 
+    /** @var string */
+    private $returnType;
+
     /**
      *
      * @param string $access
      * @param string $identifier
      * @param string $params
      * @param string $source
+     * @param string $returnType
      * @param PhpDocComment $comment
      */
-    public function __construct($access, $identifier, $params, $source, PhpDocComment $comment = null)
+    public function __construct($access, $identifier, $params, $source, PhpDocComment $comment = null, $returnType = null)
     {
         $this->access = $access;
         $this->identifier = $identifier;
         $this->params = $params;
         $this->source = $source;
         $this->comment = $comment;
+        $this->returnType = $returnType;
     }
 
     /**
@@ -64,7 +69,7 @@ class PhpFunction extends PhpElement
             $ret .= $this->getSourceRow($this->comment->getSource());
         }
 
-        $ret .= $this->getSourceRow($this->access . ' function ' . $this->identifier . '(' . $this->params . ')');
+        $ret .= $this->getSourceRow($this->access . ' function ' . $this->identifier  . '(' . $this->params . ')'. ($this->returnType ? ': ' . $this->returnType : ''));
         $ret .= $this->getSourceRow('{');
         $ret .= $this->getSourceRow($this->source);
         $ret .= $this->getSourceRow('}');

--- a/lib/PhpSource/PhpFunction.php
+++ b/lib/PhpSource/PhpFunction.php
@@ -57,6 +57,8 @@ class PhpFunction extends PhpElement
         if ( $returnType ) {
             if (substr($returnType, -2) == '[]') {
                 $this->returnType = $returnType[0] == '?' ? '?array' : 'array';
+            } else {
+                $this->returnType = $returnType;
             }
         } else {
             $this->returnType = null;

--- a/src/ComplexType.php
+++ b/src/ComplexType.php
@@ -90,7 +90,7 @@ class ComplexType extends Type
 
                 if (!$member->getNullable()) {
                     $constructorComment->addParam(PhpDocElementFactory::getParam($type, $name, ''));
-                    $constructorParameters[$name] = Validator::validateTypeHint($type);
+                    $constructorParameters[$name] = Validator::validateTypeHint($type, $this->config->get('fullTypeHints'));
                 }
             }
             $constructorSource .= '  parent::__construct(' . $this->buildParametersString($constructorParameters, false) . ');' . PHP_EOL;
@@ -100,7 +100,7 @@ class ComplexType extends Type
         foreach ($this->members as $member) {
             $type = Validator::validateType($member->getType());
             $name = Validator::validateAttribute($member->getName());
-            $typeHint = Validator::validateTypeHint($type);
+            $typeHint = Validator::validateTypeHint($type, $this->config->get('fullTypeHints'));
 
             $comment = new PhpDocComment();
             $comment->setVar(PhpDocElementFactory::getVar($type, $name, ''));
@@ -136,7 +136,7 @@ class ComplexType extends Type
             } else {
                 $getterCode = '  return $this->' . $name . ';' . PHP_EOL;
             }
-            $getter = new PhpFunction('public', 'get' . ucfirst($name), '', $getterCode, $getterComment);
+            $getter = new PhpFunction('public', 'get' . ucfirst($name), '', $getterCode, $getterComment, $this->config->get('fullTypeHints') ? '?' . $type : null );
             $accessors[] = $getter;
 
             $setterComment = new PhpDocComment();
@@ -168,7 +168,8 @@ class ComplexType extends Type
                     $member->getNullable() && !empty($typeHint)
                 ),
                 $setterCode,
-                $setterComment
+                $setterComment,
+                $this->config->get('fullTypeHints') ? 'self' : null
             );
             $accessors[] = $setter;
         }

--- a/src/Config.php
+++ b/src/Config.php
@@ -72,10 +72,12 @@ class Config implements ConfigInterface
             'operationNames'                 => '',
             'sharedTypes'                    => false,
             'constructorParamsDefaultToNull' => false,
-            'soapClientClass'               => '\SoapClient',
-            'soapClientOptions'             => array(),
-            'proxy'                         => false,
-            'async'                         => false
+            'soapClientClass'                => '\SoapClient',
+            'soapClientOptions'              => array(),
+            'proxy'                          => false,
+            'async'                          => false,
+            'fullTypeHints'                  => false,
+            'promises'                       => false
         ));
 
         // A set of configuration options names and normalizer callables.

--- a/src/Config.php
+++ b/src/Config.php
@@ -74,7 +74,8 @@ class Config implements ConfigInterface
             'constructorParamsDefaultToNull' => false,
             'soapClientClass'               => '\SoapClient',
             'soapClientOptions'             => array(),
-            'proxy'                         => false
+            'proxy'                         => false,
+            'async'                         => false
         ));
 
         // A set of configuration options names and normalizer callables.

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -246,4 +246,16 @@ class Generator implements GeneratorInterface
     {
         $this->logger = $logger;
     }
+
+    public function generateAsyncBaseClass($fileName, $namespace = null, $name = 'SoapClientAsync') {
+        $contents = file_get_contents(__DIR__ . '/SoapClientAsync.php');
+
+        if ($namespace) {
+            $contents = str_replace('namespace Wsdl2PhpGenerator;', "namespace $namespace;", $contents);
+        } else {
+            $contents = str_replace('namespace Wsdl2PhpGenerator;', '', $contents);
+        }
+        $contents = str_replace( 'class SoapClientAsync extends \SoapClient {', "class $name extends \SoapClient {", $contents);
+        file_put_contents($fileName, $contents);
+    }
 }

--- a/src/Operation.php
+++ b/src/Operation.php
@@ -130,7 +130,7 @@ class Operation
             }
         }
 
-        $ret['type'] = $paramType;
+        $ret['type'] = Validator::validateType($paramType);
 
         foreach ($validTypes as $type) {
             if ($paramType == $type->getIdentifier()) {

--- a/src/Operation.php
+++ b/src/Operation.php
@@ -86,8 +86,10 @@ class Operation
         foreach ($this->params as $value => $typeHint) {
             $ret = '';
             // Array or complex types is valid typehints
-            if ($typeHint == 'array' || $fullHints) {
+            if ($typeHint == 'array' ) {
                 $ret .= $typeHint . ' ';
+            } else if ( $fullHints ) {
+                $ret .= Validator::validateType($typeHint) . ' ';
             } else {
                 foreach ($validTypes as $type) {
                     if ($type instanceof ComplexType) {

--- a/src/Operation.php
+++ b/src/Operation.php
@@ -79,15 +79,14 @@ class Operation
      * @param Type[] $validTypes An array of Type objects with valid types for typehinting
      * @return string A parameter string
      */
-    public function getParamString(array $validTypes)
+    public function getParamString(array $validTypes, $fullHints)
     {
         $params = array();
 
         foreach ($this->params as $value => $typeHint) {
             $ret = '';
-
             // Array or complex types is valid typehints
-            if ($typeHint == 'array') {
+            if ($typeHint == 'array' || $fullHints) {
                 $ret .= $typeHint . ' ';
             } else {
                 foreach ($validTypes as $type) {

--- a/src/Service.php
+++ b/src/Service.php
@@ -205,7 +205,7 @@ class Service implements ClassGenerator
 
             $paramStr = $operation->getParamString($this->types, $this->config->get('fullTypeHints'));
 
-            $function = new PhpFunction('public', $name, $paramStr, $source, $comment, $this->config->get('fullTypeHints') ? $operation->getReturns() : null);
+            $function = new PhpFunction('public', $name, $paramStr, $source, $comment, $this->config->get('fullTypeHints') ? Validator::validateType($operation->getReturns()) : null);
 
             if ($this->class->functionExists($function->getIdentifier()) == false) {
                 $this->class->addFunction($function);

--- a/src/Service.php
+++ b/src/Service.php
@@ -210,6 +210,32 @@ class Service implements ClassGenerator
             if ($this->class->functionExists($function->getIdentifier()) == false) {
                 $this->class->addFunction($function);
             }
+
+
+            if ($this->config->get('async')) {
+                $comment = new PhpDocComment($operation->getDescription());
+
+                foreach ($operation->getParams() as $param => $hint) {
+                    $arr = $operation->getPhpDocParams($param, $this->types);
+                    $comment->addParam(PhpDocElementFactory::getParam($arr['type'], $arr['name'], $arr['desc']));
+                }
+                $comment->addParam(PhpDocElementFactory::getParam('callable', '$callback',
+                    'Callback that will get called on completion of the operation. Callback parameters: (' . $operation->getReturns() . ' $success, $error)'));
+
+                $source = '  $this->__soapCallAsync(\'' . $operation->getName() . '\', array(' . $operation->getParamStringNoTypeHints() . '), $callback);' . PHP_EOL;
+
+                $paramStr = $operation->getParamString($this->types);
+                if ($paramStr) {
+                    $paramStr .= ', ';
+                }
+                $paramStr .= 'callable $callback';
+
+                $function = new PhpFunction('public', $name . 'Async', $paramStr, $source, $comment);
+
+                if ($this->class->functionExists($function->getIdentifier()) == false) {
+                    $this->class->addFunction($function);
+                }
+            }
         }
     }
 

--- a/src/SoapClientAsync.php
+++ b/src/SoapClientAsync.php
@@ -1,0 +1,234 @@
+<?php
+
+namespace Wsdl2PhpGenerator;
+
+class SoapClientAsync extends \SoapClient {
+    private static $registry = null;
+
+    /** @var resource curl_multi resource for async calls  */
+    private $curl_multi = null;
+    /** @var array Extra options to pass to CURL  */
+    private $curl_options = null;
+    /** @var int Number of connections still active */
+    private $active = null;
+
+    /** @var array Used in the initial call to __soapRequestAsync(). Passes the callback to __doRequest() */
+    private $private_data = null;
+    /** @var string Used when a request is complete. Passes the finished result to __doRequest */
+    private $finished_result = null;
+
+    /**
+     * SoapClientAsync constructor.
+    * @param string $wsdl           URL of the WSDL
+     * @param array|null $options   Options to the SOAP client. Also, if you need additional options to pass to CURL, pass
+     *                              them as an array in the 'curl' parameter. Note that CURLOPT_RETURNTRANSFER and CURLOPT_PRIVATE
+     *                              are reserved and not usable with this implementation.
+     * @param null $curl_multi      If you wish to perform asynchronous calls to multiple SOAP services, create a manual
+     *                              CURL multi handle with curl_multi_init() and pass it to all the Soap clients in this parameter.
+     */
+    public function __construct($wsdl, array $options = null, $curl_multi = null) {
+
+        if ($options && isset($options['curl'])) {
+            $this->curl_options = $options['curl'];
+            unset($options['curl']);
+        } else {
+            $this->curl_options = array();
+        }
+
+        if (strncasecmp($wsdl, 'http://', 7) == 0 || strncasecmp($wsdl, 'https://', 8) == 0 || strncasecmp($wsdl, 'ftp://', 6) == 0) {
+            $single = curl_init($wsdl);
+            if ($this->curl_options) {
+                curl_setopt_array($single, $this->curl_options);
+            }
+
+            curl_setopt($single, CURLOPT_RETURNTRANSFER, true);
+            $contents = curl_exec($single);
+            if ($contents === false) {
+                $errno = curl_errno($single);
+                $error = curl_strerror($errno);
+            } else {
+                $contentType = curl_getinfo($single, CURLINFO_CONTENT_TYPE);
+            }
+            curl_close($single);
+            if ($contents === false) {
+                throw new \Exception($error, $errno);
+            }
+
+            $wsdl = "data://$contentType;base64,".base64_encode($contents);
+        }
+
+
+        if ($options) {
+            parent::__construct($wsdl, $options);
+        } else {
+            parent::__construct($wsdl);
+        }
+
+        $this->curl_multi = $curl_multi;
+    }
+
+    /**
+     * Performs an asynchronous SOAP call. Syntax is exactly the same as regular __soapCall, except for the added $callback parameter.
+     * @param string $methodName The name of the SOAP function to call
+     * @param array $parameters Array of parameters to the SOAP function
+     * @param callable $callback Callback that will be called when the operation is complete.
+     * @param null $options Extra options (see __soapCall)
+     * @param null $input_headers Array of input headers to be sent along
+     * @param null $output_headers Array of to be filled with the output headers
+     */
+    public function __soapCallAsync($methodName, $parameters, callable $callback, $options = null, $input_headers = null, &$output_headers = null) {
+        if (self::$registry == null) {
+            self::$registry = array();
+        }
+        $regId = uniqid();
+
+        self::$registry[$regId] = array(
+            'client' => $this,
+            'callback' => $callback,
+            'method' => $methodName,
+            'params' => $parameters
+        );
+        $this->private_data = $regId;
+        // Regular __soapCall() takes care of all the SOAP XML magic and eventually calls __doRequest();
+        $this->__soapCall($methodName, $parameters, $options, $input_headers, $output_headers);
+        $this->private_data = null;
+    }
+
+    /**
+     * Performs an actual request. Also starts/finishes an async request.
+     * @param string $request
+     * @param string $location
+     * @param string $action
+     * @param int $version
+     * @param int $one_way
+     * @return string
+     * @throws \Exception
+     */
+    public function __doRequest($request, $location, $action, $version, $one_way = 0)
+    {
+        if ($this->finished_result) {
+            return $this->finished_result;
+        }
+
+        $single = curl_init($location);
+        if ($this->curl_options) {
+            curl_setopt_array($single, $this->curl_options);
+        }
+
+        curl_setopt($single, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($single, CURLOPT_POST, true);
+        curl_setopt($single, CURLOPT_POSTFIELDS, $request);
+
+        if ($this->private_data) {
+            // Async requests
+            curl_setopt($single, CURLOPT_PRIVATE, $this->private_data);
+
+            if ($this->curl_multi === null) {
+                $this->curl_multi = curl_multi_init();
+            }
+
+            curl_multi_add_handle($this->curl_multi, $single);
+
+            $this->__processMessages_LhKI2oZ6YD();
+            return '';
+        } else {
+            // Sync requests
+            $contents = curl_exec($single);
+            if ( $contents === false ){
+                $errno = curl_errno($single);
+                $error = curl_strerror($errno);
+            }
+            curl_close($single);
+            if ($contents === false) {
+                throw new \Exception($error, $errno);
+            } else {
+                return $contents;
+            }
+        }
+    }
+
+    /**
+     * Call this repeatedly to process the outstanding connections. This method blocks for up to $timeout seconds before
+     * giving up if there is no activity. If there is any activity, processes that and returns.
+     * @param float $timeout Timeout in seconds to wait for any activity.
+     * @throws \Exception
+     */
+    public function __waitForAny($timeout = 0) {
+
+        if ($this->active) {
+            // A long standing bug in PHP - if curl_multi_select() returns -1, you need to sleep for teensy tiny bit and try again. Mostly even a single microsecond is enough.
+            // See: https://bugs.php.net/bug.php?id=61141
+            do {
+                $ret = curl_multi_select($this->curl_multi, $timeout);
+                if ($ret === -1) {
+                    usleep(250);
+                }
+            } while ($ret === -1);
+        }
+
+        $this->__processMessages_LhKI2oZ6YD();
+    }
+
+    /** Waits until all the requests have finished processing. */
+    public function __waitForAll() {
+        while ($this->active) {
+            $this->__waitForAny(1000);
+        }
+    }
+
+    /** Processes whatever is done. */
+    private function __processMessages_LhKI2oZ6YD() {
+        do {
+            // Process as far as possible at the moment.
+            $ret = curl_multi_exec($this->curl_multi, $this->active);
+        } while ($ret == CURLM_CALL_MULTI_PERFORM);
+
+        if ($ret != CURLM_OK) {
+            throw new \Exception(curl_multi_strerror($ret), $ret);
+        }
+
+        while ($message = curl_multi_info_read($this->curl_multi)) {
+            $handle = $message['handle'];
+            $tagId = curl_getinfo($handle, CURLINFO_PRIVATE);
+            if (!is_string($tagId) || self::$registry == null || !isset(self::$registry[$tagId])) {
+                continue;
+            }
+            $tag = self::$registry[$tagId];
+            unset(self::$registry[$tagId]);
+
+            $status = curl_getinfo($handle, CURLINFO_HTTP_CODE);
+            $contents = curl_multi_getcontent($handle);
+            curl_multi_remove_handle($this->curl_multi, $handle);
+            curl_close($handle);
+
+            if ($message['result'] != CURLE_OK || $status != 200) {
+                call_user_func($tag['callback'], null, array(
+                    'curl_errno' => $message['result'],
+                    'curl_error' => curl_strerror($message['result']),
+                    'http_code' => $status,
+                    'http_contents' => $contents
+                ));
+
+                continue;
+            }
+
+            try {
+                /** @var SoapClientAsync $client */
+                $client = $tag['client'];
+                $client->finished_result = $contents;
+                $goodResult = $client->__soapCall($tag['method'], $tag['params']);
+                $badResult = null;
+            } catch (\Exception $ex) {
+                $goodResult = null;
+                $badResult = $ex;
+            }
+
+            if (is_soap_fault($goodResult)) {
+                $badResult = $goodResult;
+                $goodResult = null;
+            }
+
+            call_user_func($tag['callback'], $goodResult, $badResult);
+        }
+    }
+}

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -218,6 +218,7 @@ class Validator
             case "token":
             case "normalizedstring":
             case "hexbinary":
+            case "date":
                 return 'string';
             case "datetime":
                 return  '\DateTime';

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -209,22 +209,20 @@ class Validator
             case "unsignedlong":
             case "unsignedshort":
                 return 'int';
-                break;
             case "float":
             case "double":
             case "decimal":
                 return 'float';
-                break;
             case "<anyxml>":
             case "string":
             case "token":
             case "normalizedstring":
             case "hexbinary":
                 return 'string';
-                break;
             case "datetime":
                 return  '\DateTime';
-                break;
+            case "boolean":
+                return 'bool';
             default:
                 $typeName = self::validateNamingConvention($typeName);
                 break;

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -4,13 +4,15 @@
  */
 namespace Wsdl2PhpGenerator;
 
+use Transliterator;
+
 /**
  * Class that contains functionality to validate a string as valid php
  * Contains functionf for validating Type, Classname and Naming convention
  *
  * @package Wsdl2PhpGenerator
  * @author Fredrik Wallgren <fredrik.wallgren@gmail.com>
- * @license http://www.opensource.org/licenses/mit-license.php MIT License
+*  * @license http://www.opensource.org/licenses/mit-license.php MIT License
  */
 class Validator
 {
@@ -241,7 +243,7 @@ class Validator
      * @param string $typeName The name of the type to test.
      * @return null|string Returns a valid type hint for the type or null if there is no valid type hint.
      */
-    public static function validateTypeHint($typeName)
+    public static function validateTypeHint($typeName, $fullTypes)
     {
         $typeHint = null;
 
@@ -250,8 +252,8 @@ class Validator
         // strings and not class instances and we have no way of determining whether the type is an enum at this point.
         if (substr($typeName, -2) == "[]") {
             $typeHint = 'array';
-        } elseif ($typeName == '\DateTime') {
-            $typeHint = $typeName;
+        } elseif ($typeName == '\DateTime' || $fullTypes) {
+            $typeHint = ($fullTypes ? '?' : '') . $typeName;
         }
 
         return $typeHint;
@@ -293,7 +295,7 @@ class Validator
      */
     private static function validateNamingConvention($name)
     {
-        $name = iconv("UTF-8", "ASCII//TRANSLIT", $name);
+        $name =  Transliterator::create('Any-Latin; Latin-ASCII')->transliterate($name);
 
         // Prepend the string a to names that begin with anything but a-z This is to make a valid name
         if (preg_match('/^[A-Za-z_]/', $name) == false) {


### PR DESCRIPTION
When you need to make multiple unrelated SOAP requests (like querying several services) and you need to make them _FAST_, an indispensable tool is running these requests in parallel. PHP isn't really known for it's asyc/multithreading features, but with CURL it is possible. There are a few `SoapClient` implementations out there that leverage this, but none of them are compatible with **wsdl2phpgenerator**, nor are their interfaces easily adaptable for it. This pull request is my attempt to make it possible.

Since PHP's default SoapClient class does not offer any async capabilities this relies on a custom base class. The requirements for this base class are as simple as possible - a single additional `__soapCallAsync()` method which is identical to the `__soapCall()` but takes an extra callback parameter. That's all.

The generator then gets two additional features - the `async` option generates `xxxAsync()` methods which call the `__soapCallAsync()` of the base class; and the `generateAsyncBaseClass()` method generates an example base class (which is still fully functional and probably enough for most projects).

This retains full backwards compatibility and these new options are not used unless explicitly invoked.