### PR TITLE
Fix implements exception

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=5.3.0",
         "ext-soap": "*",
-        "symfony/options-resolver": "~2.6|~3.0",
+        "symfony/options-resolver": "~2.6|~3.0|~4.0",
         "symfony/polyfill-iconv": "^1.2"
     },
     "require-dev": {

--- a/lib/PhpSource/PhpClass.php
+++ b/lib/PhpSource/PhpClass.php
@@ -48,7 +48,7 @@ class PhpClass extends PhpElement
      * @var string[]
      * @access private
      */
-    private $implements;
+    private $implements = array();
 
     /**
      *


### PR DESCRIPTION
When addImplementation, in PhpClass, is not called, $this->implements is null.
In this case, an error is throen in:

if (count($this->implements) > 0) {
            $ret .= ' implements ' . implode(', ', $this->implements);
}


