### PR TITLE
Initialising $this->implements as an empty array to stop count() yiel…

### DIFF
--- a/lib/PhpSource/PhpClass.php
+++ b/lib/PhpSource/PhpClass.php
@@ -103,6 +103,7 @@ class PhpClass extends PhpElement
     public function __construct($identifier, $classExists = false, $extends = '', PhpDocComment $comment = null, $final = false, $abstract = false)
     {
         $this->dependencies = array();
+        $this->implements = array();
         $this->classExists = $classExists;
         $this->comment = $comment;
         $this->final = $final;


### PR DESCRIPTION
$this->implements is not initialised as an empty array, and because of it, this code:

`if (count($this->implements) > 0)`

on line 156 will yield a warning from PHP 7.2 as this PHP version introduced changes to count():
http://php.net/manual/en/function.count.php
