### PR TITLE
adding option "libxmlStreamContext" to Config

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -74,7 +74,8 @@ class Config implements ConfigInterface
             'constructorParamsDefaultToNull' => false,
             'soapClientClass'               => '\SoapClient',
             'soapClientOptions'             => array(),
-            'proxy'                         => false
+            'proxy'                         => false,
+            'libxmlStreamContext' => null,
         ));
 
         // A set of configuration options names and normalizer callables.
@@ -83,6 +84,7 @@ class Config implements ConfigInterface
             'operationNames' => array($this, 'normalizeArray'),
             'soapClientOptions' => array($this, 'normalizeSoapClientOptions'),
             'proxy' => array($this, 'normalizeProxy'),
+            'libxmlStreamContext' => array($this, 'normalizeLibxmlStreamContext')
         );
         // Convert each callable to a closure as that is required by OptionsResolver->setNormalizer().
         $normalizers = array_map(function ($callable) {
@@ -211,5 +213,22 @@ class Config implements ConfigInterface
         $value['proxy_port'] = intval($value['proxy_port']);
 
         return $value;
+    }
+    
+    protected function normalizeLibxmlStreamContext(Options $options, $value)
+    {
+        if (empty($value)) {
+            return null;
+        }
+        
+        if (is_resource($value)) {
+            return $value;
+        }
+        
+        if (is_array($value)) {
+            return stream_context_create($value);
+        }
+        
+        throw new InvalidArgumentException('libxmlStreamContext option should be an array of a resource from stream_context_create');
     }
 }

--- a/src/StreamContextFactory.php
+++ b/src/StreamContextFactory.php
@@ -18,6 +18,12 @@ class StreamContextFactory
      */
     public function create(ConfigInterface $config)
     {
+        $libxmlStreamContext = $config->get('libxmlStreamContext');
+        
+        if ($libxmlStreamContext) {
+            return $libxmlStreamContext;
+        }
+        
         $options = array();
         $headers = array();
 

--- a/tests/src/Unit/StreamContextFactoryTest.php
+++ b/tests/src/Unit/StreamContextFactoryTest.php
@@ -3,7 +3,6 @@
 
 namespace Wsdl2PhpGenerator\Tests\Unit;
 
-
 use Wsdl2PhpGenerator\Config;
 use Wsdl2PhpGenerator\StreamContextFactory;
 
@@ -113,5 +112,66 @@ class StreamContextFactoryTest extends \PHPUnit_Framework_TestCase
 
         $header = 'Proxy-Authorization: Basic ' . base64_encode($proxy['login'] . ':' . $proxy['password']);
         $this->assertContains($header, $options['http']['header']);
+    }
+    
+    /**
+     * Test that <Config> accepts libxmlStreamContext both as array or resource
+     * @
+     */
+    public function testStreamContextOverrideAlternatives()
+    {
+        $libxmlStreamContext = array(
+            'ssl' => array(
+                'verify_peer'		 => false,
+                'verify_peer_name'	 => false,
+                'allow_self_signed'	 => true
+            )
+        );
+        
+        new Config(array(
+            'inputFile' => null,
+            'outputDir' => null,
+            'libxmlStreamContext' => $libxmlStreamContext
+        ));
+        $this->addToAssertionCount(1);
+        
+        new Config(array(
+            'inputFile' => null,
+            'outputDir' => null,
+            'libxmlStreamContext' => stream_context_create($libxmlStreamContext)
+        ));
+        $this->addToAssertionCount(1);
+    }
+    
+    /**
+     * Test that the generated stream context matches the options passed to the <Config>
+     */
+    public function testStreamContextOverrideResult()
+    {
+        $config = new Config(array(
+            'inputFile' => null,
+            'outputDir' => null,
+            'libxmlStreamContext' => array(
+                'ssl' => array(
+                    'verify_peer'		 => false,
+                    'verify_peer_name'	 => false,
+                    'allow_self_signed'	 => true
+                )
+            
+        )));
+        
+        $streamContextFactory = new StreamContextFactory();
+        $resource = $streamContextFactory->create($config);
+
+        $options = stream_context_get_options($resource);
+        
+        $this->assertArrayHasKey('ssl', $options);
+        $this->assertArrayHasKey('verify_peer', $options['ssl']);
+        $this->assertArrayHasKey('verify_peer_name', $options['ssl']);
+        $this->assertArrayHasKey('allow_self_signed', $options['ssl']);
+        
+        $this->assertEquals($options['ssl']['verify_peer'], false);
+        $this->assertEquals($options['ssl']['verify_peer_name'], false);
+        $this->assertEquals($options['ssl']['allow_self_signed'], true);
     }
 }


### PR DESCRIPTION
Added the option `libxmlStreamContext` to `Wsdl2PhpGenerator\Config`, that allows the override of the _stream_context_ used by the libxml to load the external resources.

I needed this on a project in which I had to set the ssl option for the _stream context_, and thought it would be more flexible to allow the replacement of the stream_context_create instead of just add the ssl option ( eg.: `proxy` option )

Description:

If the `libxmlStreamContext` is declared the `StreamContextFactory` use this option instead of creating a new stream context.

The `libxmlStreamContext` can be an array or a resource created by `stream_context_create`, if its an array it is normalized by passing said array directly to `stream_context_create`.

Usage example:
```php
$config = new Config(array(
	'inputFile' => null,
	'outputDir' => null,
	'libxmlStreamContext' => array(
		'ssl' => array(
			'verify_peer'		 => false,
			'verify_peer_name'	 => false,
			'allow_self_signed'	 => true
		)
        )
));
// or:
$config = new Config(array(
	'inputFile' => null,
	'outputDir' => null,
	'libxmlStreamContext' => stream_context_create(array(
		'ssl' => array(
			'verify_peer'		 => false,
			'verify_peer_name'	 => false,
			'allow_self_signed'	 => true
		)
        ))
));
```

Let me know if I missed something and if this option is useful :+1: 