### PR TITLE
PHP 7.2 fix - count(null) - with sintaxe PHP 5.x

### DIFF
--- a/lib/PhpSource/PhpClass.php
+++ b/lib/PhpSource/PhpClass.php
@@ -48,7 +48,7 @@ class PhpClass extends PhpElement
      * @var string[]
      * @access private
      */
-    private $implements;
+    private $implements = array();
 
     /**
      *
@@ -61,21 +61,21 @@ class PhpClass extends PhpElement
      *
      * @var array Array of constants key = name of constant value = value of constant
      */
-    private $constants;
+    private $constants = array();
 
     /**
      *
      * @var PhpVariable[]
      * @access private
      */
-    private $variables;
+    private $variables = array();
 
     /**
      *
      * @var PhpFunction[]
      * @access private
      */
-    private $functions;
+    private $functions = array();
 
     /**
      *


### PR DESCRIPTION
Bug "count(): Parameter must be an array or an object that implements Countable".