### PR TITLE
Set PHP 7.2  as minimum requirement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,6 @@ env:
   - PREFER_LOWEST="--prefer-lowest"
   - PREFER_LOWEST=""
 
-sudo: false
-
 before_script:
   - composer update --no-interaction $PREFER_LOWEST
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ php:
   - 7.3
   - 7.4
 
+# until PHPUnit upgrade allow PHP 7.4 to fails
+allow_failures:
+  - php: 7.4
+
 env:
   - PREFER_LOWEST="--prefer-lowest"
   - PREFER_LOWEST=""

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,9 @@ php:
   - 7.2
   - 7.3
   - 7.4
-
-# until PHPUnit upgrade allow PHP 7.4 to fails
-allow_failures:
-  - php: 7.4
+  # until PHPUnit upgrade allow PHP 7.4 to fails
+  allow_failures:
+    - php: 7.4
 
 env:
   - PREFER_LOWEST="--prefer-lowest"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,14 @@ language: php
 php:
   - 7.2
   - 7.3
+  - 7.4
+
+jobs:
+  allow_failures:
+    - php: 7.4
+      env: PREFER_LOWEST=""
+    - php: 7.4
+      env: PREFER_LOWEST="--prefer-lowest"
 
 env:
   - PREFER_LOWEST="--prefer-lowest"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,13 @@
 language: php
 
 php:
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
-  - 7.1
+  - 7.2
+  - 7.3
+  - 7.4
 
 env:
   - PREFER_LOWEST="--prefer-lowest"
   - PREFER_LOWEST=""
-
-matrix:
-  include:
-    # PHP 5.3 builds have to be included manually as they require precise
-    - php: 5.3
-      dist: precise
-      env: PREFER_LOWEST="--prefer-lowest"
-    - php: 5.3
-      dist: precise
-      env: PREFER_LOWEST=""
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,6 @@ language: php
 php:
   - 7.2
   - 7.3
-  - 7.4
-  # until PHPUnit upgrade allow PHP 7.4 to fails
-  allow_failures:
-    - php: 7.4
 
 env:
   - PREFER_LOWEST="--prefer-lowest"

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^7.2",
         "ext-soap": "*",
-        "symfony/options-resolver": "^2.6|^3.0",
+        "symfony/options-resolver": "^3.4.37",
         "symfony/polyfill-iconv": "^1.2"
     },
     "require-dev": {
@@ -26,7 +26,7 @@
         "phing/phing": "^2.7",
         "php-vcr/php-vcr": "1.2.6 - 1.2.7|^1.3.1",
         "php-vcr/phpunit-testlistener-vcr": "^1.1.2",
-        "phpunit/phpunit": "^4.4",
+        "phpunit/phpunit": "^4.8.36",
         "psr/log": "^1.0",
         "symfony/yaml": "^2.1"
     }

--- a/composer.json
+++ b/composer.json
@@ -25,9 +25,9 @@
         "kasperg/phing-github": "0.2.*",
         "phing/phing": "^2.16.3",
         "php-vcr/php-vcr": "^1.4.4",
-        "php-vcr/phpunit-testlistener-vcr": "^1.1.7",
-        "phpunit/phpunit": "^4.8.36",
+        "phpunit/phpunit": "^6.0",
         "psr/log": "^1.1.2",
-        "symfony/yaml": "^2.8.52"
+        "symfony/yaml": "^2.8.52",
+        "php-vcr/phpunit-testlistener-vcr": "3.0.*"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -16,18 +16,18 @@
         }
     },
     "require": {
-        "php": ">=5.3.0",
+        "php": "^7.2",
         "ext-soap": "*",
-        "symfony/options-resolver": "~2.6|~3.0",
+        "symfony/options-resolver": "^2.6|^3.0",
         "symfony/polyfill-iconv": "^1.2"
     },
     "require-dev": {
         "kasperg/phing-github": "0.2.*",
-        "phing/phing": "~2.7",
+        "phing/phing": "^2.7",
         "php-vcr/php-vcr": "1.2.6 - 1.2.7|^1.3.1",
-        "php-vcr/phpunit-testlistener-vcr": "~1.1.2",
-        "phpunit/phpunit": "~4.4",
-        "psr/log": "~1.0",
-        "symfony/yaml": "~2.1"
+        "php-vcr/phpunit-testlistener-vcr": "^1.1.2",
+        "phpunit/phpunit": "^4.4",
+        "psr/log": "^1.0",
+        "symfony/yaml": "^2.1"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -19,15 +19,15 @@
         "php": "^7.2",
         "ext-soap": "*",
         "symfony/options-resolver": "^3.4.37",
-        "symfony/polyfill-iconv": "^1.2"
+        "symfony/polyfill-iconv": "^1.13.1"
     },
     "require-dev": {
         "kasperg/phing-github": "0.2.*",
-        "phing/phing": "^2.7",
-        "php-vcr/php-vcr": "1.2.6 - 1.2.7|^1.3.1",
-        "php-vcr/phpunit-testlistener-vcr": "^1.1.2",
+        "phing/phing": "^2.16.3",
+        "php-vcr/php-vcr": "^1.4.4",
+        "php-vcr/phpunit-testlistener-vcr": "^1.1.7",
         "phpunit/phpunit": "^4.8.36",
-        "psr/log": "^1.0",
-        "symfony/yaml": "^2.1"
+        "psr/log": "^1.1.2",
+        "symfony/yaml": "^2.8.52"
     }
 }

--- a/lib/PhpSource/PhpClass.php
+++ b/lib/PhpSource/PhpClass.php
@@ -48,7 +48,7 @@ class PhpClass extends PhpElement
      * @var string[]
      * @access private
      */
-    private $implements;
+    private $implements = [];
 
     /**
      *
@@ -61,21 +61,21 @@ class PhpClass extends PhpElement
      *
      * @var array Array of constants key = name of constant value = value of constant
      */
-    private $constants;
+    private $constants = [];
 
     /**
      *
      * @var PhpVariable[]
      * @access private
      */
-    private $variables;
+    private $variables = [];
 
     /**
      *
      * @var PhpFunction[]
      * @access private
      */
-    private $functions;
+    private $functions = [];
 
     /**
      *

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -27,7 +27,7 @@
     </testsuites>
 
     <listeners>
-        <listener class="PHPUnit_Util_Log_VCR" file="vendor/php-vcr/phpunit-testlistener-vcr/PHPUnit/Util/Log/VCR.php" />
+        <listener class="VCR\PHPUnit\TestListener\VCRTestListener" file="vendor/php-vcr/phpunit-testlistener-vcr/src/VCRTestListener.php" />
     </listeners>
 
     <logging>

--- a/tests/src/Unit/CodeGenerationTestCase.php
+++ b/tests/src/Unit/CodeGenerationTestCase.php
@@ -2,20 +2,19 @@
 
 namespace Wsdl2PhpGenerator\Tests\Unit;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use ReflectionMethod;
 use ReflectionParameter;
 use ReflectionProperty;
 use Wsdl2PhpGenerator\ClassGenerator;
-use Wsdl2PhpGenerator\Type;
 
 /**
  * Base class for testing code generation.
  *
  * Contains various assertions for examining code.
  */
-class CodeGenerationTestCase extends PHPUnit_Framework_TestCase
+class CodeGenerationTestCase extends TestCase
 {
 
     /**

--- a/tests/src/Unit/ConfigTest.php
+++ b/tests/src/Unit/ConfigTest.php
@@ -2,10 +2,10 @@
 
 namespace Wsdl2PhpGenerator\Tests\Unit;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Wsdl2PhpGenerator\Config;
 
-class ConfigTest extends PHPUnit_Framework_TestCase
+class ConfigTest extends TestCase
 {
     protected $options;
     protected $config;

--- a/tests/src/Unit/Filter/ServiceOperationFilterTest.php
+++ b/tests/src/Unit/Filter/ServiceOperationFilterTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Wsdl2PhpGenerator\Tests\Unit\Filter;
 
+use PHPUnit\Framework\TestCase;
 use Wsdl2PhpGenerator\ComplexType;
 use Wsdl2PhpGenerator\Config;
 use Wsdl2PhpGenerator\ConfigInterface;
@@ -12,7 +13,7 @@ use Wsdl2PhpGenerator\Service;
 /**
  * Use test for the ServiceOperationFilter class.
  */
-class ServiceOperationFilterTest extends \PHPUnit_Framework_TestCase
+class ServiceOperationFilterTest extends TestCase
 {
     /**
      * @var ConfigInterface

--- a/tests/src/Unit/StreamContextFactoryTest.php
+++ b/tests/src/Unit/StreamContextFactoryTest.php
@@ -4,13 +4,14 @@
 namespace Wsdl2PhpGenerator\Tests\Unit;
 
 
+use PHPUnit\Framework\TestCase;
 use Wsdl2PhpGenerator\Config;
 use Wsdl2PhpGenerator\StreamContextFactory;
 
 /**
  * Unit test for the stream context factory.
  */
-class StreamContextFactoryTest extends \PHPUnit_Framework_TestCase
+class StreamContextFactoryTest extends TestCase
 {
 
     /**

--- a/tests/src/Unit/ValidatorTest.php
+++ b/tests/src/Unit/ValidatorTest.php
@@ -4,7 +4,7 @@
  */
 namespace Wsdl2PhpGenerator\Tests\Unit;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Wsdl2PhpGenerator\Validator;
 
 /**
@@ -13,7 +13,7 @@ use Wsdl2PhpGenerator\Validator;
  *
  * @package wsdl2phpTest
  */
-class ValidatorTest extends PHPUnit_Framework_TestCase
+class ValidatorTest extends TestCase
 {
 
     /**


### PR DESCRIPTION
Also update the requirements for other packages (which does not change the actual packages used).
Fixes #378.
Closes #383.