### PR TITLE
Drop the symfony/yaml dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,8 +32,7 @@
         "php-vcr/phpunit-testlistener-vcr": "^3.2.1",
         "phpstan/phpstan": "^0.12.9",
         "phpunit/phpunit": "^8.5",
-        "psr/log": "^1.1.2",
-        "symfony/yaml": "^2.8.52"
+        "psr/log": "^1.1.2"
     },
     "scripts": {
         "test": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "68dc25234c4fab57050da91e9a9d2e8a",
+    "content-hash": "7cd09e68d523b1d75ccce52eb438e688",
     "packages": [
         {
             "name": "symfony/options-resolver",
@@ -3229,26 +3229,35 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v2.8.52",
+            "version": "v4.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "02c1859112aa779d9ab394ae4f3381911d84052b"
+                "reference": "cd014e425b3668220adb865f53bff64b3ad21767"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/02c1859112aa779d9ab394ae4f3381911d84052b",
-                "reference": "02c1859112aa779d9ab394ae4f3381911d84052b",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/cd014e425b3668220adb865f53bff64b3ad21767",
+                "reference": "cd014e425b3668220adb865f53bff64b3ad21767",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.9",
+                "php": "^7.1.3",
                 "symfony/polyfill-ctype": "~1.8"
+            },
+            "conflict": {
+                "symfony/console": "<3.4"
+            },
+            "require-dev": {
+                "symfony/console": "^3.4|^4.0|^5.0"
+            },
+            "suggest": {
+                "symfony/console": "For validating YAML files using the lint command"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.8-dev"
+                    "dev-master": "4.4-dev"
                 }
             },
             "autoload": {
@@ -3275,7 +3284,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2018-11-11T11:18:13+00:00"
+            "time": "2020-01-21T11:12:16+00:00"
         },
         {
             "name": "theseer/tokenizer",


### PR DESCRIPTION
This package depends on `symfony/yaml`, but I could not find any reference to that library. Furthermore, it requires version 2.8 which is unmaintained.

`symfony/yaml` is however a requirement for `php-vcr/php-vcr`, but that package should be compatible with more recent versions of `symfony/yaml`.

This PR removes the direct dependency on `symfony/yaml` and bumps that package to version 4.4.4 which is currently the most recent version allowed by `php-vcr/php-vcr` (pending php-vcr/php-vcr#287).