### PR TITLE
Use error message from xml document

### DIFF
--- a/src/Xml/SchemaDocument.php
+++ b/src/Xml/SchemaDocument.php
@@ -55,7 +55,7 @@ class SchemaDocument extends XmlNode
         $document = new DOMDocument();
         $loaded   = $document->load($xsdUrl);
         if (!$loaded) {
-            throw new Exception('Unable to load XML from '.$xsdUrl);
+            throw new Exception(libxml_get_last_error()->message);
         }
 
         parent::__construct($document, $document->documentElement);


### PR DESCRIPTION
Will generate a message like `failed to load external entity "https://...?xsd=xsd2"`. 